### PR TITLE
Add blocked label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -2,6 +2,10 @@
   description: Something isn't working
   color: d42a34
 
+- name: blocked
+  description: Cannot address this till other issues are solved first
+  color: e0b063
+
 - name: dependencies
   description: Related with project dependencies
   color: ffc0cb


### PR DESCRIPTION
Adding a new label to identify which issues or PR are blocked due to other pending tasks.