### PR TITLE
Doc Makefile: Remove trailing '/*' from rm statement

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -21,6 +21,6 @@ help:
 
 # Customized clean due to examples gallery
 clean:
-	rm -rf $(BUILDDIR)/*
+	rm -rf $(BUILDDIR)
 	rm -rf $(SOURCEDIR)/examples
 	find . -type d -name "_autosummary" -exec rm -rf {} +


### PR DESCRIPTION
Fixes #154.

Remove the trailing '/*' from 'rm -rf $BUILDDIR/*'. This avoids accidental 
hard drive deletion when $BUILDDIR is not set.
