### PR TITLE
Consume flake8 from github instead of gitlab mirror

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,8 +10,8 @@ repos:
   hooks:
   - id: isort
 
-- repo: https://gitlab.com/PyCQA/flake8
-  rev: 4.0.1
+- repo: https://github.com/PyCQA/flake8
+  rev: 5.0.4
   hooks:
   - id: flake8
     args: [

--- a/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/.pre-commit-config.yaml
+++ b/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/.pre-commit-config.yaml
@@ -10,8 +10,8 @@ repos:
   hooks:
   - id: isort
 
-- repo: https://gitlab.com/PyCQA/flake8
-  rev: 4.0.1
+- repo: https://github.com/PyCQA/flake8
+  rev: 5.0.4
   hooks:
   - id: flake8
 


### PR DESCRIPTION
In the pre-commit configuration for flake8, refer to the 'main' repository on GitHub, instead of its GitLab mirror.

Update the flake8 version to '5.0.4'.

Using the gitlab mirror caused 'pre-commit autoupdate' to not pick up new versions (at least in my project, didn't try to consistently reproduce this).