### PR TITLE
DOC: fix version button

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -22,7 +22,7 @@ html_theme_options = {
         "json_url": "https://raw.githubusercontent.com/ansys/ansys-templates/gh-pages/release/version_mapper.json",
         "version_match": "dev" if version.endswith("dev0") else version,
     },
-    "navbar_end": ["version-switcher"]
+    "navbar_start": ["navbar-logo", "version-switcher"],
 }
 
 # Sphinx extensions


### PR DESCRIPTION
After merging #160, the version button is no longer appearing. This pull-request tries to solve that issue.