### PR TITLE
MAINT: downgrade sphinx to 5.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ tests = [
 doc = [
     "ansys-sphinx-theme==0.8.0",
     "numpydoc==1.5.0",
-    "sphinx==6.1.2",
+    "sphinx==5.3.0",
     "sphinx-copybutton==0.5.1",
 ]
 


### PR DESCRIPTION
Downgrades the Sphinx version to version 5.3.0 to avoid missing icons in the top navigation bar.