### PR TITLE
Update sidebar-nav-bs.html

### DIFF
--- a/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/doc/source/_templates/sidebar-nav-bs.html
+++ b/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/doc/source/_templates/sidebar-nav-bs.html
@@ -2,9 +2,9 @@
   <div class="bd-toc-item active">
     {{
     '{% if pagename.startswith("_autosummary") or pagename.startswith("api")%}
-    {{ generate_nav_html("sidebar", maxdepth=4, collapse=True, includehidden=True, titles_only=True) }}
+    {{ generate_toctree_html("sidebar", maxdepth=4, collapse=True, includehidden=True, titles_only=True) }}
     {% else %}
-    {{ generate_nav_html("sidebar", maxdepth=4, collapse=False, includehidden=True, titles_only=True) }}
+    {{ generate_toctree_html("sidebar", maxdepth=4, collapse=False, includehidden=True, titles_only=True) }}
     {% endif %}
     '
     }}


### PR DESCRIPTION
Getting rid of warning:

```txt
WARNING: `generate_nav_html` is deprecated and will be removed. Use `generate_toctree_html` instead.   
```