### PR TITLE
Fix broken tracelens image on compose.yaml

### DIFF
--- a/src/ansys/templates/python/solution/{{cookiecutter.__project_name_slug}}/compose.yaml
+++ b/src/ansys/templates/python/solution/{{cookiecutter.__project_name_slug}}/compose.yaml
@@ -28,7 +28,7 @@ services:
       - "host.docker.internal:host-gateway"
 
   tracelens:
-    image: docker.io/rogeralsing/tracelens:amd64
+    image: azwepsifujiaksacr.azurecr.io/ansys/md1-obs/tracelens:latest
     ports:
       - 5000:5001
       - 4317:4317


### PR DESCRIPTION
The tracelens image used by compose.yaml is currently broken. This is now using a tracelens image hosted on fuji environment.