### PR TITLE
Fix compose.yaml not being distributed as part of the solution template

### DIFF
--- a/src/ansys/templates/python/solution/hooks/post_gen_project.py
+++ b/src/ansys/templates/python/solution/hooks/post_gen_project.py
@@ -39,6 +39,7 @@ DESIRED_STRUCTURE = [
     "CHANGELOG.md",
     "CODE_OF_CONDUCT.md",
     "CODEOWNERS",
+    "compose.yaml",
     "CONTRIBUTING.md",
     "CONTRIBUTORS.md",
     "LICENSE.rst",


### PR DESCRIPTION
`compose.yaml` is part of the solution template in the repository, but is not distributed once the template has been executed.
This PR fixes this issue and makes `compose.yaml` part of the created solution 