### PR TITLE
fix: limit upper version of cookiecutter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
 env:
   MAIN_PYTHON_VERSION : '3.10'
   LIBRARY_NAME: 'ansys-templates'
-  LIBRARY_NAMESPACE: 'ansys.templates'
   DOCUMENTATION_CNAME: 'templates.ansys.com'
 
 concurrency:
@@ -62,7 +61,6 @@ jobs:
         uses: ansys/actions/build-wheelhouse@v4
         with:
           library-name: ${{ env.LIBRARY_NAME }}
-          library-namespace: ${{ env.LIBRARY_NAMESPACE }}
           operating-system: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 dependencies = [
     "importlib-metadata >=4.0",
     "click>=7.0,<9.0.0",
-    "cookiecutter>=2.1.0",
+    "cookiecutter>=2.1.0,<2.3.0",
     "isort>=5.10.1",
 ]
 


### PR DESCRIPTION
This pull-request limits the version of cookiecutter for solving the latest CI/CD issues.