### PR TITLE
[REFACTORING] General refactoring of the osl-template

### DIFF
--- a/src/ansys/templates/python/osl_solution/hooks/post_gen_project.py
+++ b/src/ansys/templates/python/osl_solution/hooks/post_gen_project.py
@@ -32,7 +32,7 @@ DESIRED_STRUCTURE = [
     f"src/ansys/solutions/{{ cookiecutter.__solution_name_slug }}/ui/components/actor_logs_table.py",
     f"src/ansys/solutions/{{ cookiecutter.__solution_name_slug }}/ui/components/actor_statistics_table.py",
     f"src/ansys/solutions/{{ cookiecutter.__solution_name_slug }}/ui/components/button_group.py",
-    f"src/ansys/solutions/{{ cookiecutter.__solution_name_slug }}/ui/components/commands.py",
+    f"src/ansys/solutions/{{ cookiecutter.__solution_name_slug }}/ui/components/node_control.py",
     f"src/ansys/solutions/{{ cookiecutter.__solution_name_slug }}/ui/components/design_table.py",
     f"src/ansys/solutions/{{ cookiecutter.__solution_name_slug }}/ui/components/logs_table.py",
     f"src/ansys/solutions/{{ cookiecutter.__solution_name_slug }}/ui/components/project_information_table.py",

--- a/src/ansys/templates/python/osl_solution/hooks/post_gen_project.py
+++ b/src/ansys/templates/python/osl_solution/hooks/post_gen_project.py
@@ -23,6 +23,7 @@ DESIRED_STRUCTURE = [
     f"src/ansys/solutions/{{ cookiecutter.__solution_name_slug }}/model/assets/README.md",
     f"src/ansys/solutions/{{ cookiecutter.__solution_name_slug }}/solution/definition.py",
     f"src/ansys/solutions/{{ cookiecutter.__solution_name_slug }}/solution/problem_setup_step.py",
+    f"src/ansys/solutions/{{ cookiecutter.__solution_name_slug }}/solution/monitoring_step.py",
     f"src/ansys/solutions/{{ cookiecutter.__solution_name_slug }}/ui/assets/css/style.css",
     f"src/ansys/solutions/{{ cookiecutter.__solution_name_slug }}/ui/assets/images/README.md",
     f"src/ansys/solutions/{{ cookiecutter.__solution_name_slug }}/ui/assets/logos/ansys-solutions-horizontal-logo.png",

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/poetry.lock
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/poetry.lock
@@ -3830,4 +3830,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8, <3.11"
-content-hash = "561eb374de8c3a9cc4f5d1335a107264eb8f95cf80b1e072e880501e9e129415"
+content-hash = "de6eb34f2b0b51da930d3420b066f17e45d73056ed62e3dec97709dc1fcb20ab"

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/poetry.lock
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/poetry.lock
@@ -283,22 +283,6 @@ url = "https://pkgs.dev.azure.com/pyansys/_packaging/ansys-solutions/pypi/simple
 reference = "solutions-private-pypi"
 
 [[package]]
-name = "ansys-solutions-products-ecosystem"
-version = "0.1.dev0"
-description = ""
-optional = false
-python-versions = ">=3.8,<3.11"
-files = [
-    {file = "ansys-solutions-products-ecosystem-0.1.dev0.tar.gz", hash = "sha256:23a68f100675d85371f5911c99ab5f3498702b2c05374fd772db104499f56dc8"},
-    {file = "ansys_solutions_products_ecosystem-0.1.dev0-py3-none-any.whl", hash = "sha256:e2d44ee3ccd9f7200e80982760647eb9949af77e65be10c2d6ae831731867d18"},
-]
-
-[package.source]
-type = "legacy"
-url = "https://pkgs.dev.azure.com/pyansys/_packaging/ansys-solutions/pypi/simple"
-reference = "solutions-private-pypi"
-
-[[package]]
 name = "ansys-sphinx-theme"
 version = "0.8.2"
 description = "A theme devised by ANSYS, Inc. for Sphinx documentation."
@@ -3846,4 +3830,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8, <3.11"
-content-hash = "a351e2badf3129f9802422e4cb995b617c167f319068f2bc6e5e3e1621f0c34b"
+content-hash = "561eb374de8c3a9cc4f5d1335a107264eb8f95cf80b1e072e880501e9e129415"

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/pyproject.toml
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/pyproject.toml
@@ -48,7 +48,6 @@ ansys-dash-treeview = {version = "0.0.1.dev0", source = "solutions-private-pypi"
 ansys-optislang-core = {git = "https://github.com/ansys/pyoptislang.git", rev = "dd780ae"} # Temporarily pointing to the GitHub repo until next release is available.
 ansys-saf-glow = {version = "0.4.dev4", source = "solutions-private-pypi"}
 ansys-saf-portal = {version = "0.5.dev0", source = "solutions-private-pypi"}
-ansys-solutions-dash-lib = {version = "0.4.5", source = "solutions-private-pypi"}
 ansys-solutions-optislang-frontend-components = {version = "0.1.dev10", source = "solutions-private-pypi"}
 optislang-dash-lib = {version = "^0.2.1", source = "solutions-private-pypi"}
 dash = "^2.6"

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/pyproject.toml
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/pyproject.toml
@@ -49,7 +49,6 @@ ansys-optislang-core = {git = "https://github.com/ansys/pyoptislang.git", rev = 
 ansys-saf-glow = {version = "0.4.dev4", source = "solutions-private-pypi"}
 ansys-saf-portal = {version = "0.5.dev0", source = "solutions-private-pypi"}
 ansys-solutions-dash-lib = {version = "0.4.5", source = "solutions-private-pypi"}
-ansys-solutions-products-ecosystem = {version = "^0.1.dev0", source = "solutions-private-pypi"}
 ansys-solutions-optislang-frontend-components = {version = "0.1.dev10", source = "solutions-private-pypi"}
 optislang-dash-lib = {version = "^0.2.1", source = "solutions-private-pypi"}
 dash = "^2.6"

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/solution/definition.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/solution/definition.py
@@ -5,11 +5,13 @@
 from ansys.saf.glow.solution import Solution, StepsModel
 
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.problem_setup_step import ProblemSetupStep
+from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.monitoring_step import MonitoringStep
 
 
 class Steps(StepsModel):
     """Workflow definition."""
     problem_setup_step: ProblemSetupStep
+    monitoring_step: MonitoringStep
 
 
 class {{ cookiecutter.__solution_definition_name }}(Solution):

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/solution/monitoring_step.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/solution/monitoring_step.py
@@ -168,9 +168,6 @@ class MonitoringStep(StepModel):
             ]
         ),
         self=StepSpec(
-            download=[
-                "optislang_log_level",
-            ],
             upload=[
                 "actors_info",
                 "actors_status_info",
@@ -198,7 +195,7 @@ class MonitoringStep(StepModel):
 
         # Configure logging.
         osl_logger = logging.OslLogger(
-            loglevel=self.optislang_log_level,
+            loglevel=problem_setup_step.optislang_log_level,
             log_to_file=True,
             logfile_name=self.optislang_log_file.path,
             log_to_stdout=True,

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/solution/monitoring_step.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/solution/monitoring_step.py
@@ -236,7 +236,7 @@ class MonitoringStep(StepModel):
             self.transaction.upload(["optislang_logs"])
             if self.project_state == "FINISHED":
                 break
-            time.sleep(3)
+            time.sleep(3) # Waiting 3 sec before pulling new data. The frequency might be adjusted in the future.
 
         # Close connection with optiSLang server.
         osl.dispose()

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/solution/monitoring_step.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/solution/monitoring_step.py
@@ -1,0 +1,282 @@
+# ©2023, ANSYS Inc. Unauthorized use, distribution or duplication is prohibited.
+
+"""Backend of the problem setup step."""
+
+import time
+
+from pathlib import Path
+from typing import List, Optional
+
+from ansys.optislang.core import Optislang, logging
+from ansys.saf.glow.solution import StepModel, StepSpec, long_running, transaction, FileReference
+
+from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.problem_setup_step import ProblemSetupStep
+from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.utilities.common_functions import read_log_file
+
+
+class MonitoringStep(StepModel):
+    """Step model of the monitoring step."""
+
+    # Parameters ------------------------------------------------------------------------------------------------------
+
+    # Frontend persistence
+    selected_actor_from_treeview: Optional[str] = None
+    selected_command: Optional[str] = None
+    selected_actor_from_command: Optional[str] = None
+    commands_locked: bool = False
+    auto_update_frequency: float = 2000
+    auto_update_activated: bool = True
+    actor_uid: Optional[str] = None
+    project_command_execution_status: dict = {"alert-message": "", "alert-color": "info"}
+    actor_command_execution_status: dict = {"alert-message": "", "alert-color": "info"}
+    project_btn_group_options: List = [
+                                {
+                                    "icon": "fas fa-play",
+                                    "tooltip": "Restart optiSLang project.",
+                                    "value": "restart",
+                                    "id": {
+                                        "type":"action-button",
+                                        "action":"restart"
+                                    }
+                                },
+                                {
+                                    "icon":"fa fa-hand-paper",
+                                    "tooltip": "Stop optiSLang project gently.",
+                                    "value": "stop_gently",
+                                    "id": {
+                                        "type":"action-button",
+                                        "action":"stop_gently"
+                                    }
+                                },
+                                {
+                                    "icon": "fas fa-stop",
+                                    "tooltip":"Stop optiSLang project.",
+                                    "value": "stop",
+                                    "id": {
+                                        "type": "action-button",
+                                        "action":"stop"
+                                        }
+                                    },
+                                {
+                                    "icon": "fas fa-fast-backward",
+                                    "tooltip": "Reset optiSLang project.",
+                                    "value": "reset",
+                                    "id": {
+                                        "type":"action-button",
+                                        "action":"reset"
+                                        }
+                                    },
+                                {
+                                    "icon": "fas fa-power-off",
+                                    "tooltip": "Shutdown optiSLang project.",
+                                    "value": "shutdown",
+                                    "id": {
+                                        "type":"action-button",
+                                        "action":"shutdown"
+                                    }
+                                },
+                            ]
+    actor_btn_group_options: List = [
+                            {
+                                "icon": "fas fa-play",
+                                "tooltip": "Restart node.",
+                                "value": "restart",
+                                "id": {
+                                    "type":"action-button",
+                                    "action":"restart"
+                                }
+                            },
+
+                            {
+                                "icon":"fa fa-hand-paper",
+                                "tooltip": "Stop node gently.",
+                                "value": "stop_gently",
+                                "id": {
+                                    "type":"action-button",
+                                    "action":"stop_gently"
+                                }
+                            },
+
+                            {
+                                "icon": "fas fa-stop",
+                                "tooltip":"Stop node.",
+                                "value": "stop",
+                                "id": {
+                                    "type": "action-button",
+                                    "action":"stop"
+                                }
+                            },
+
+                            {
+                                "icon": "fas fa-fast-backward",
+                                "tooltip": "Reset node.",
+                                "value": "reset",
+                                "id": {
+                                    "type":"action-button",
+                                    "action":"reset"
+                                }
+                            },
+                        ]
+
+    # Backend data model
+    project_status_info: dict = {}
+    actors_info: dict = {}
+    actors_status_info: dict = {}
+    results_files: dict = {}
+    project_state: str = "NOT STARTED"
+    osl_project_states: List = [
+        "IDLE",
+        "PROCESSING",
+        "PAUSED",
+        "PAUSE_REQUESTED",
+        "STOPPED",
+        "STOP_REQUESTED",
+        "GENTLY_STOPPED",
+        "GENTLE_STOP_REQUESTED",
+        "FINISHED"
+    ]
+    osl_actor_states: List = [
+        "Idle",
+        "Succeeded",
+        "Failed",
+        "Running",
+        "Aborted",
+        "Predecessor failed",
+        "Skipped",
+        "Incomplete",
+        "Processing done",
+        "Stopped",
+        "Gently stopped"
+    ]
+    optislang_logs: List = []
+    optislang_log_level: str = "INFO"
+    command_timeout: int = 30
+
+    # File storage ----------------------------------------------------------------------------------------------------
+
+    # Output
+    optislang_log_file: FileReference = FileReference("Problem_Setup/pyoptislang.log")
+
+    # Methods ---------------------------------------------------------------------------------------------------------
+
+    @transaction(
+        problem_setup_step=StepSpec(
+            download=[
+                "tcp_server_host",
+                "tcp_server_port",
+                "project_tree",
+                "optislang_log_level",
+            ]
+        ),
+        self=StepSpec(
+            download=[
+                "optislang_log_level",
+            ],
+            upload=[
+                "actors_info",
+                "actors_status_info",
+                "optislang_logs",
+                "optislang_log_file",
+                "project_state",
+                "project_status_info",
+                "results_files",
+            ],
+        )
+    )
+    @long_running
+    def upload_project_data(self, problem_setup_step: ProblemSetupStep) -> None:
+        """Monitor the progress of the optiSLang project and continuously upload project data."""
+
+        # Connect to optiSLang instance.
+        osl = Optislang(
+            host=problem_setup_step.tcp_server_host,
+            port=problem_setup_step.tcp_server_port,
+            loglevel=self.optislang_log_level,
+            shutdown_on_finished=False
+        )
+
+        # Configure logging.
+        osl_logger = logging.OslLogger(
+            loglevel=self.optislang_log_level,
+            log_to_file=True,
+            logfile_name=self.optislang_log_file.path,
+            log_to_stdout=True,
+        )
+        osl.__logger = osl_logger.add_instance_logger(osl.name, osl, problem_setup_step.optislang_log_level)
+
+        # Monitor project state and upload data.
+        while True:
+            # Get project state
+            self.project_state = osl.project.get_status()
+            osl.log.info(f"Analysis status: {self.project_state}")
+            # Get project status info
+            self.project_status_info = osl.get_osl_server().get_full_project_status_info()
+            # Read pyoptislang logs
+            self.optislang_logs = read_log_file(self.optislang_log_file.path)
+            # Get actor status info
+            for node_info in problem_setup_step.project_tree:
+                if node_info["uid"] == osl.project.root_system.uid:
+                    node = osl.project.root_system
+                else:
+                    node = osl.project.root_system.find_node_by_uid(node_info["uid"], search_depth=-1)
+                self.actors_info[node.uid] = osl.get_osl_server().get_actor_info(node.uid)
+                if node.get_states_ids():
+                    self.actors_status_info[node.uid] = []
+                    for hid in node.get_states_ids():
+                        self.actors_status_info[node.uid].append(
+                            osl.get_osl_server().get_actor_status_info(node.uid, hid)
+                        )
+            # Upload fields
+            self.transaction.upload(["project_state"])
+            self.transaction.upload(["project_status_info"])
+            self.transaction.upload(["actors_info"])
+            self.transaction.upload(["actors_status_info"])
+            self.transaction.upload(["optislang_logs"])
+            if self.project_state == "FINISHED":
+                break
+            time.sleep(3)
+
+        # Close connection with optiSLang server.
+        osl.dispose()
+
+    @transaction(
+        problem_setup_step=StepSpec(
+            download=[
+                "tcp_server_host",
+                "tcp_server_port",
+                "project_tree",
+                "optislang_log_level",
+            ]
+        ),
+        self=StepSpec(
+            download=[
+                "command_timeout",
+                "selected_actor_from_command",
+                "selected_command"
+            ],
+            upload=["actor_uid"],
+        )
+    )
+    def control_node_state(self, problem_setup_step: ProblemSetupStep) -> None:
+        """Update the state of root or actor node based on the project command in the UI."""
+        osl = Optislang(
+                host=problem_setup_step.tcp_server_host,
+                port=problem_setup_step.tcp_server_port,
+                shutdown_on_finished=False
+            )
+        if not self.selected_actor_from_command == "shutdown":
+            if self.selected_actor_from_command == osl.project.root_system.uid:
+                node = osl.project.root_system
+                self.actor_uid = None
+            else:
+                node = osl.project.root_system.find_node_by_uid(self.selected_actor_from_command, search_depth=-1)
+                self.actor_uid = node
+        else:
+            node = osl.project.root_system
+
+        status = node.control(self.selected_command, wait_for_completion=True, timeout=self.command_timeout)
+
+        if not status:
+            raise Exception(f"{self.selected_command.replace('_', ' ').title()} command against node {node.get_name()} failed.")
+
+        osl.dispose()

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/solution/monitoring_step.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/solution/monitoring_step.py
@@ -149,7 +149,6 @@ class MonitoringStep(StepModel):
         "Gently stopped"
     ]
     optislang_logs: List = []
-    optislang_log_level: str = "INFO"
     command_timeout: int = 30
 
     # File storage ----------------------------------------------------------------------------------------------------
@@ -187,12 +186,14 @@ class MonitoringStep(StepModel):
     def upload_project_data(self, problem_setup_step: ProblemSetupStep) -> None:
         """Monitor the progress of the optiSLang project and continuously upload project data."""
 
+        Path(self.optislang_log_file.path).parent.mkdir(parents=True, exist_ok=True)
+
         # Connect to optiSLang instance.
         osl = Optislang(
             host=problem_setup_step.tcp_server_host,
             port=problem_setup_step.tcp_server_port,
-            loglevel=self.optislang_log_level,
-            shutdown_on_finished=False
+            loglevel=problem_setup_step.optislang_log_level,
+            shutdown_on_finished=True
         )
 
         # Configure logging.
@@ -245,14 +246,13 @@ class MonitoringStep(StepModel):
                 "tcp_server_host",
                 "tcp_server_port",
                 "project_tree",
-                "optislang_log_level",
             ]
         ),
         self=StepSpec(
             download=[
                 "command_timeout",
                 "selected_actor_from_command",
-                "selected_command"
+                "selected_command",
             ],
             upload=["actor_uid"],
         )

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/solution/problem_setup_step.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/solution/problem_setup_step.py
@@ -10,11 +10,11 @@ import tempfile
 from pathlib import Path
 from typing import List, Optional
 
-from ansys.optislang.core import Optislang, logging, utils
+from ansys.optislang.core import Optislang, utils
 from ansys.saf.glow.solution import FileReference, FileGroupReference, StepModel, StepSpec, long_running, transaction
 from ansys.solutions.optislang.frontend_components.project_properties import ProjectProperties, write_properties_file, apply_placeholders_to_properties_file
 
-from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.utilities.common_functions import get_treeview_items_from_project_tree, read_log_file
+from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.utilities.common_functions import get_treeview_items_from_project_tree
 
 
 class ProblemSetupStep(StepModel):
@@ -33,7 +33,7 @@ class ProblemSetupStep(StepModel):
     tcp_server_port: Optional[int] = None
     ansys_ecosystem: dict = {
         "optislang": {
-            "authorized_versions": [231, 232],
+            "authorized_versions": [],
             "installed_versions": [],
             "compatible_versions": [],
             "selected_version": None,
@@ -163,12 +163,15 @@ class ProblemSetupStep(StepModel):
         self.ansys_ecosystem_ready = True
 
         # Collect optiSLang installations
-        self.ansys_ecosystem["optislang"]["installed_versions"] = list(dict(utils.find_all_osl_exec()).keys())
-        self.ansys_ecosystem["optislang"]["compatible_versions"] = [
-            product_version
-            for product_version in self.ansys_ecosystem["optislang"]["installed_versions"]
-            if product_version in self.ansys_ecosystem["optislang"]["authorized_versions"]
-        ]
+        self.ansys_ecosystem["optislang"]["installed_versions"] = sorted(list(dict(utils.find_all_osl_exec()).keys()))
+        if len(self.ansys_ecosystem["optislang"]["authorized_versions"]) > 0:
+            self.ansys_ecosystem["optislang"]["compatible_versions"] = [
+                product_version
+                for product_version in self.ansys_ecosystem["optislang"]["installed_versions"]
+                if product_version in self.ansys_ecosystem["optislang"]["authorized_versions"]
+            ]
+        else:
+            self.ansys_ecosystem["optislang"]["compatible_versions"] = self.ansys_ecosystem["optislang"]["installed_versions"]
 
         # Check ecosystem
         for product_name in self.ansys_ecosystem.keys():

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/solution/problem_setup_step.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/solution/problem_setup_step.py
@@ -13,7 +13,6 @@ from typing import List, Optional
 from ansys.optislang.core import Optislang, logging, utils
 from ansys.saf.glow.solution import FileReference, FileGroupReference, StepModel, StepSpec, long_running, transaction
 from ansys.solutions.optislang.frontend_components.project_properties import ProjectProperties, write_properties_file, apply_placeholders_to_properties_file
-from ansys.solutions.products_ecosystem.controller import AnsysProductsEcosystemController
 
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.utilities.common_functions import get_treeview_items_from_project_tree, read_log_file
 
@@ -170,19 +169,6 @@ class ProblemSetupStep(StepModel):
             for product_version in self.ansys_ecosystem["optislang"]["installed_versions"]
             if product_version in self.ansys_ecosystem["optislang"]["authorized_versions"]
         ]
-
-        # Collect additonnal Ansys products installations
-        controller = AnsysProductsEcosystemController()
-        for product_name in self.ansys_ecosystem.keys():
-            if product_name != "optislang":
-                self.ansys_ecosystem[product_name]["installed_versions"] = controller.get_installed_versions(
-                    product_name, output_format="long"
-                )
-                self.ansys_ecosystem[product_name]["compatible_versions"] = [
-                    product_version
-                    for product_version in self.ansys_ecosystem[product_name]["installed_versions"]
-                    if product_version in self.ansys_ecosystem[product_name]["authorized_versions"]
-                ]
 
         # Check ecosystem
         for product_name in self.ansys_ecosystem.keys():

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/solution/problem_setup_step.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/solution/problem_setup_step.py
@@ -50,6 +50,16 @@ class ProblemSetupStep(StepModel):
     criteria: dict = {}
     ui_placeholders: dict = {}
     app_metadata: dict = {}
+    project_tree: list = []
+    treeview_items: list = [
+        {
+            "key": "problem_setup_step",
+            "text": "Problem Setup",
+            "depth": 0,
+            "uid": None
+        },
+    ]
+    optislang_log_level: str = "INFO"
     
     # File storage ----------------------------------------------------------------------------------------------------
 
@@ -57,14 +67,12 @@ class ProblemSetupStep(StepModel):
     project_file: FileReference = FileReference("Problem_Setup/{{ cookiecutter.__optiSLang_application_archive_stem }}.opf")
     properties_file: FileReference = FileReference("Problem_Setup/{{ cookiecutter.__optiSLang_application_archive_stem }}.json")
     metadata_file: FileReference = FileReference("Problem_Setup/metadata.json")
-    project_state_file: FileReference = FileReference("Problem_Setup/project_state.json")
     input_files: FileGroupReference = FileGroupReference("Problem_Setup/Input_Files/*.*")
     # If folder doesn't exist, it will be created later
     upload_directory: str = os.path.join(tempfile.gettempdir(), "GLOW")
 
     # Outputs
     working_properties_file: FileReference = FileReference("Problem_Setup/working_properties_file.json")
-    optislang_log_file: FileReference = FileReference("Problem_Setup/pyoptislang.log")
 
     # Methods ---------------------------------------------------------------------------------------------------------
 
@@ -258,6 +266,7 @@ class ProblemSetupStep(StepModel):
                 "input_files",
                 "project_file",
                 "working_properties_file",
+                "optislang_log_level"
             ],
             upload=[
                 "tcp_server_host",
@@ -273,6 +282,7 @@ class ProblemSetupStep(StepModel):
         osl = Optislang(
             project_path=self.project_file.path,
             reset=True,
+            loglevel=self.optislang_log_level,
             shutdown_on_finished=False,
             import_project_properties_file=self.working_properties_file.path,
             ini_timeout=300,  # might need to be adjusted depending on the hardware

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/solution/problem_setup_step.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/solution/problem_setup_step.py
@@ -88,7 +88,6 @@ class ProblemSetupStep(StepModel):
     @long_running
     def upload_bulk_files_to_project_directory(self) -> None:
         """Upload bulk files to project directory."""
-
         original_project_file = Path(__file__).parent.absolute().parent / "model" / "assets" / "{{ cookiecutter.__optiSLang_application_archive_stem }}.opf"
         self.project_file.write_bytes(original_project_file.read_bytes())
 
@@ -131,6 +130,7 @@ class ProblemSetupStep(StepModel):
         )
     )
     def write_updated_properties_file(self) -> None:
+        """Write updated optiSLang project properties file."""
         properties = apply_placeholders_to_properties_file(self.ui_placeholders, self.properties_file.path)
         self.placeholders = properties["placeholders"]
         self.registered_files = properties["registered_files"]
@@ -146,6 +146,7 @@ class ProblemSetupStep(StepModel):
         )
     )
     def update_osl_placeholders_with_ui_values(self) -> None:
+        """Update placeholders with values selected by the user in the UI."""
         properties = apply_placeholders_to_properties_file(self.ui_placeholders, self.properties_file.path)
         self.placeholders = properties["placeholders"]
         self.registered_files = properties["registered_files"]
@@ -160,7 +161,6 @@ class ProblemSetupStep(StepModel):
     )
     def check_ansys_ecosystem(self) -> None:
         """Check if Ansys Products are installed and if the appropriate versions are available."""
-
         self.ansys_ecosystem_ready = True
 
         # Collect optiSLang installations
@@ -227,7 +227,6 @@ class ProblemSetupStep(StepModel):
     @long_running
     def get_app_metadata(self) -> None:
         """Read OWA metadata file."""
-
         with open(self.metadata_file.path) as f:
             self.app_metadata = json.load(f)
 
@@ -245,7 +244,6 @@ class ProblemSetupStep(StepModel):
     @long_running
     def get_project_tree(self) -> None:
         """Get the project tree of the optiSLang project."""
-
         # Start optiSLang instance.
         osl = Optislang(
             project_path=self.project_file.path,
@@ -276,7 +274,6 @@ class ProblemSetupStep(StepModel):
     )
     def start(self) -> None:
         """Start optiSLang and run the project."""
-
         # Start optiSLang instance.
         osl = Optislang(
             project_path=self.project_file.path,

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/solution/problem_setup_step.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/solution/problem_setup_step.py
@@ -60,7 +60,7 @@ class ProblemSetupStep(StepModel):
         },
     ]
     optislang_log_level: str = "INFO"
-    
+
     # File storage ----------------------------------------------------------------------------------------------------
 
     # Inputs

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/solution/problem_setup_step.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/solution/problem_setup_step.py
@@ -274,7 +274,6 @@ class ProblemSetupStep(StepModel):
             ],
         )
     )
-    @long_running
     def start(self) -> None:
         """Start optiSLang and run the project."""
 

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/actor_information_table.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/actor_information_table.py
@@ -1,6 +1,7 @@
 # ©2023, ANSYS Inc. Unauthorized use, distribution or duplication is prohibited.
 
 import dash_bootstrap_components as dbc
+import json
 import pandas as pd
 import plotly.express as px
 import uuid
@@ -107,13 +108,16 @@ class ActorInformationTableAIO(html.Div):
 
     def get_data(self, monitoring_step: MonitoringStep) -> pd.DataFrame:
 
-        if monitoring_step.selected_actor_from_treeview in monitoring_step.actors_info.keys():
-            actor_info = monitoring_step.actors_info[monitoring_step.selected_actor_from_treeview]
+        actors_info = json.loads(monitoring_step.actors_info_file.read_text())
+        actors_status_info = json.loads(monitoring_step.actors_status_info.read_text())
+
+        if monitoring_step.selected_actor_from_treeview in actors_info.keys():
+            actor_info = actors_info[monitoring_step.selected_actor_from_treeview]
         else:
             actor_info = {}
 
-        if monitoring_step.selected_actor_from_treeview in monitoring_step.actors_status_info.keys():
-            actor_status_info = monitoring_step.actors_status_info[monitoring_step.selected_actor_from_treeview][0]
+        if monitoring_step.selected_actor_from_treeview in actors_status_info.keys():
+            actor_status_info = actors_status_info[monitoring_step.selected_actor_from_treeview][0]
         else:
             actor_status_info = {}
 

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/actor_information_table.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/actor_information_table.py
@@ -8,7 +8,7 @@ import uuid
 from dash_extensions.enrich import html, dash_table, dcc
 
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.definition import {{ cookiecutter.__solution_definition_name }}
-from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.problem_setup_step import ProblemSetupStep
+from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.monitoring_step import MonitoringStep
 
 
 class ActorInformationTableAIO(html.Div):
@@ -27,11 +27,11 @@ class ActorInformationTableAIO(html.Div):
 
     ids = ids
 
-    def __init__(self, problem_setup_step: ProblemSetupStep, aio_id: str = None):
+    def __init__(self, monitoring_step: MonitoringStep, aio_id: str = None):
         """ActorInformationTableAIO is an All-in-One component that is composed
         of a parent `html.Div` with a `dcc.Interval` and a `dash_table.DataTable` as children.
 
-        - `problem_setup_step` - The StepModel object of the problem setup step.
+        - `monitoring_step` - The StepModel object of the monitoring step.
         - `datatable_props` - A dictionary of properties passed into the dash_table.DataTable component.
         - `interval_props` - A dictionary of properties passed into the dcc.Interval component.
         - `aio_id` - The All-in-One component ID used to generate the table components's dictionary IDs.
@@ -40,7 +40,7 @@ class ActorInformationTableAIO(html.Div):
         if aio_id is None:
             aio_id = str(uuid.uuid4())
 
-        table_data, pie_chart_data = self.get_data(problem_setup_step)
+        table_data, pie_chart_data = self.get_data(monitoring_step)
 
         datatable_props = {
             "data": table_data.to_dict('records'),
@@ -105,15 +105,15 @@ class ActorInformationTableAIO(html.Div):
             )
         ])
 
-    def get_data(self, problem_setup_step) -> pd.DataFrame:
+    def get_data(self, monitoring_step: MonitoringStep) -> pd.DataFrame:
 
-        if problem_setup_step.selected_actor_from_treeview in problem_setup_step.actors_info.keys():
-            actor_info = problem_setup_step.actors_info[problem_setup_step.selected_actor_from_treeview]
+        if monitoring_step.selected_actor_from_treeview in monitoring_step.actors_info.keys():
+            actor_info = monitoring_step.actors_info[monitoring_step.selected_actor_from_treeview]
         else:
             actor_info = {}
 
-        if problem_setup_step.selected_actor_from_treeview in problem_setup_step.actors_status_info.keys():
-            actor_status_info = problem_setup_step.actors_status_info[problem_setup_step.selected_actor_from_treeview][0]
+        if monitoring_step.selected_actor_from_treeview in monitoring_step.actors_status_info.keys():
+            actor_status_info = monitoring_step.actors_status_info[monitoring_step.selected_actor_from_treeview][0]
         else:
             actor_status_info = {}
 

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/actor_information_table.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/actor_information_table.py
@@ -109,7 +109,7 @@ class ActorInformationTableAIO(html.Div):
     def get_data(self, monitoring_step: MonitoringStep) -> pd.DataFrame:
 
         actors_info = json.loads(monitoring_step.actors_info_file.read_text())
-        actors_status_info = json.loads(monitoring_step.actors_status_info.read_text())
+        actors_status_info = json.loads(monitoring_step.actors_status_info_file.read_text())
 
         if monitoring_step.selected_actor_from_treeview in actors_info.keys():
             actor_info = actors_info[monitoring_step.selected_actor_from_treeview]

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/actor_logs_table.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/actor_logs_table.py
@@ -8,7 +8,7 @@ from dash_extensions.enrich import html, dash_table
 from datetime import datetime
 
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.definition import {{ cookiecutter.__solution_definition_name }}
-from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.problem_setup_step import ProblemSetupStep
+from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.monitoring_step import MonitoringStep
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.utilities.common_functions import (
     remove_key_from_dictionaries,
     sort_dict_by_ordered_keys,
@@ -26,11 +26,11 @@ class ActorLogsTableAIO(html.Div):
 
     ids = ids
 
-    def __init__(self, problem_setup_step: ProblemSetupStep, aio_id: str = None):
+    def __init__(self, monitoring_step: MonitoringStep, aio_id: str = None):
         """ActorLogsTableAIO is an All-in-One component that is composed
         of a parent `html.Div` with a `dcc.Interval` and a `dash_table.DataTable` as children.
 
-        - `problem_setup_step` - The StepModel object of the problem setup step.
+        - `monitoring_step` - The StepModel object of the monitoring step.
         - `datatable_props` - A dictionary of properties passed into the dash_table.DataTable component.
         - `interval_props` - A dictionary of properties passed into the dcc.Interval component.
         - `aio_id` - The All-in-One component ID used to generate the table components's dictionary IDs.
@@ -39,7 +39,7 @@ class ActorLogsTableAIO(html.Div):
         if aio_id is None:
             aio_id = str(uuid.uuid4())
 
-        data = self.get_data(problem_setup_step)
+        data = self.get_data(monitoring_step)
 
         datatable_props = {
             "data": data.to_dict('records'),
@@ -88,10 +88,10 @@ class ActorLogsTableAIO(html.Div):
             )
         ])
 
-    def get_data(self, problem_setup_step) -> pd.DataFrame:
+    def get_data(self, monitoring_step: MonitoringStep) -> pd.DataFrame:
 
-        if problem_setup_step.selected_actor_from_treeview in problem_setup_step.actors_info.keys():
-            actor_info = problem_setup_step.actors_info[problem_setup_step.selected_actor_from_treeview]
+        if monitoring_step.selected_actor_from_treeview in monitoring_step.actors_info.keys():
+            actor_info = monitoring_step.actors_info[monitoring_step.selected_actor_from_treeview]
         else:
             actor_info = {}
 

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/actor_logs_table.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/actor_logs_table.py
@@ -1,6 +1,7 @@
 # ©2023, ANSYS Inc. Unauthorized use, distribution or duplication is prohibited.
 
 import dash_bootstrap_components as dbc
+import json
 import pandas as pd
 import uuid
 
@@ -90,8 +91,10 @@ class ActorLogsTableAIO(html.Div):
 
     def get_data(self, monitoring_step: MonitoringStep) -> pd.DataFrame:
 
-        if monitoring_step.selected_actor_from_treeview in monitoring_step.actors_info.keys():
-            actor_info = monitoring_step.actors_info[monitoring_step.selected_actor_from_treeview]
+        actors_info = json.loads(monitoring_step.actors_info_file.read_text())
+
+        if monitoring_step.selected_actor_from_treeview in actors_info.keys():
+            actor_info = actors_info[monitoring_step.selected_actor_from_treeview]
         else:
             actor_info = {}
 

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/actor_statistics_table.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/actor_statistics_table.py
@@ -7,7 +7,7 @@ import uuid
 from dash_extensions.enrich import html, dash_table
 
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.definition import {{ cookiecutter.__solution_definition_name }}
-from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.problem_setup_step import ProblemSetupStep
+from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.monitoring_step import MonitoringStep
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.utilities.common_functions import convert_microseconds
 
 
@@ -22,11 +22,11 @@ class ActorStatisticsTableAIO(html.Div):
 
     ids = ids
 
-    def __init__(self, problem_setup_step: ProblemSetupStep, aio_id: str = None):
+    def __init__(self, monitoring_step: MonitoringStep, aio_id: str = None):
         """ActorStatisticsTableAIO is an All-in-One component that is composed
         of a parent `html.Div` with a `dcc.Interval` and a `dash_table.DataTable` as children.
 
-        - `problem_setup_step` - The StepModel object of the problem setup step.
+        - `monitoring_step` - The StepModel object of the monitoring step.
         - `datatable_props` - A dictionary of properties passed into the dash_table.DataTable component.
         - `interval_props` - A dictionary of properties passed into the dcc.Interval component.
         - `aio_id` - The All-in-One component ID used to generate the table components's dictionary IDs.
@@ -35,7 +35,7 @@ class ActorStatisticsTableAIO(html.Div):
         if aio_id is None:
             aio_id = str(uuid.uuid4())
 
-        data = self.get_data(problem_setup_step)
+        data = self.get_data(monitoring_step)
 
         datatable_props = {
             "data": data.to_dict('records'),
@@ -83,10 +83,10 @@ class ActorStatisticsTableAIO(html.Div):
             )
         ])
 
-    def get_data(self, problem_setup_step) -> pd.DataFrame:
+    def get_data(self, monitoring_step: MonitoringStep) -> pd.DataFrame:
 
-        if problem_setup_step.selected_actor_from_treeview in problem_setup_step.actors_info.keys():
-            actor_info = problem_setup_step.actors_info[problem_setup_step.selected_actor_from_treeview]
+        if monitoring_step.selected_actor_from_treeview in monitoring_step.actors_info.keys():
+            actor_info = monitoring_step.actors_info[monitoring_step.selected_actor_from_treeview]
         else:
             actor_info = {}
 

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/actor_statistics_table.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/actor_statistics_table.py
@@ -1,6 +1,7 @@
 # ©2023, ANSYS Inc. Unauthorized use, distribution or duplication is prohibited.
 
 import dash_bootstrap_components as dbc
+import json
 import pandas as pd
 import uuid
 
@@ -85,8 +86,10 @@ class ActorStatisticsTableAIO(html.Div):
 
     def get_data(self, monitoring_step: MonitoringStep) -> pd.DataFrame:
 
-        if monitoring_step.selected_actor_from_treeview in monitoring_step.actors_info.keys():
-            actor_info = monitoring_step.actors_info[monitoring_step.selected_actor_from_treeview]
+        actors_info = json.loads(monitoring_step.actors_info_file.read_text())
+
+        if monitoring_step.selected_actor_from_treeview in actors_info.keys():
+            actor_info = actors_info[monitoring_step.selected_actor_from_treeview]
         else:
             actor_info = {}
 

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/design_table.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/design_table.py
@@ -1,6 +1,7 @@
 # ©2023, ANSYS Inc. Unauthorized use, distribution or duplication is prohibited.
 
 import dash_bootstrap_components as dbc
+import json
 import pandas as pd
 import uuid
 
@@ -97,13 +98,16 @@ class DesignTableAIO(html.Div):
 
     def get_data(self, monitoring_step: MonitoringStep) -> pd.DataFrame:
 
-        if monitoring_step.selected_actor_from_treeview in monitoring_step.actors_info.keys():
-            actor_info = monitoring_step.actors_info[monitoring_step.selected_actor_from_treeview]
+        actors_info = json.loads(monitoring_step.actors_info_file.read_text())
+        actors_status_info = json.loads(monitoring_step.actors_status_info.read_text())
+
+        if monitoring_step.selected_actor_from_treeview in actors_info.keys():
+            actor_info = actors_info[monitoring_step.selected_actor_from_treeview]
         else:
             actor_info = {}
 
-        if monitoring_step.selected_actor_from_treeview in monitoring_step.actors_status_info.keys():
-            actor_status_info = monitoring_step.actors_status_info[monitoring_step.selected_actor_from_treeview][0]
+        if monitoring_step.selected_actor_from_treeview in actors_status_info.keys():
+            actor_status_info = actors_status_info[monitoring_step.selected_actor_from_treeview][0]
         else:
             actor_status_info = {}
 

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/design_table.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/design_table.py
@@ -7,7 +7,7 @@ import uuid
 from dash_extensions.enrich import html, dash_table
 
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.definition import {{ cookiecutter.__solution_definition_name }}
-from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.problem_setup_step import ProblemSetupStep
+from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.monitoring_step import MonitoringStep
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.utilities.common_functions import sorted_nicely
 
 
@@ -22,11 +22,11 @@ class DesignTableAIO(html.Div):
 
     ids = ids
 
-    def __init__(self, problem_setup_step: ProblemSetupStep, aio_id: str = None):
+    def __init__(self, monitoring_step: MonitoringStep, aio_id: str = None):
         """DesignTableAIO is an All-in-One component that is composed
         of a parent `html.Div` with a `dcc.Interval` and a `dash_table.DataTable` as children.
 
-        - `problem_setup_step` - The StepModel object of the problem setup step.
+        - `monitoring_step` - The StepModel object of the monitoring step.
         - `datatable_props` - A dictionary of properties passed into the dash_table.DataTable component.
         - `interval_props` - A dictionary of properties passed into the dcc.Interval component.
         - `aio_id` - The All-in-One component ID used to generate the table components's dictionary IDs.
@@ -35,7 +35,7 @@ class DesignTableAIO(html.Div):
         if aio_id is None:
             aio_id = str(uuid.uuid4())
 
-        data = self.get_data(problem_setup_step)
+        data = self.get_data(monitoring_step)
 
         datatable_props = {
             "data": data.to_dict('records'),
@@ -95,15 +95,15 @@ class DesignTableAIO(html.Div):
         sorted_designs = sorted_nicely(designs)
         return [designs.index(design) for design in sorted_designs]
 
-    def get_data(self, problem_setup_step) -> pd.DataFrame:
+    def get_data(self, monitoring_step: MonitoringStep) -> pd.DataFrame:
 
-        if problem_setup_step.selected_actor_from_treeview in problem_setup_step.actors_info.keys():
-            actor_info = problem_setup_step.actors_info[problem_setup_step.selected_actor_from_treeview]
+        if monitoring_step.selected_actor_from_treeview in monitoring_step.actors_info.keys():
+            actor_info = monitoring_step.actors_info[monitoring_step.selected_actor_from_treeview]
         else:
             actor_info = {}
 
-        if problem_setup_step.selected_actor_from_treeview in problem_setup_step.actors_status_info.keys():
-            actor_status_info = problem_setup_step.actors_status_info[problem_setup_step.selected_actor_from_treeview][0]
+        if monitoring_step.selected_actor_from_treeview in monitoring_step.actors_status_info.keys():
+            actor_status_info = monitoring_step.actors_status_info[monitoring_step.selected_actor_from_treeview][0]
         else:
             actor_status_info = {}
 

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/design_table.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/design_table.py
@@ -99,7 +99,7 @@ class DesignTableAIO(html.Div):
     def get_data(self, monitoring_step: MonitoringStep) -> pd.DataFrame:
 
         actors_info = json.loads(monitoring_step.actors_info_file.read_text())
-        actors_status_info = json.loads(monitoring_step.actors_status_info.read_text())
+        actors_status_info = json.loads(monitoring_step.actors_status_info_file.read_text())
 
         if monitoring_step.selected_actor_from_treeview in actors_info.keys():
             actor_info = actors_info[monitoring_step.selected_actor_from_treeview]

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/node_control.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/node_control.py
@@ -13,16 +13,16 @@ from ansys.saf.glow.core.method_status import MethodStatus
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.definition import {{ cookiecutter.__solution_definition_name }}
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.button_group import ButtonGroup
 
-class ProjectCommandsAIO(html.Div):
+class NodeControlAIO(html.Div):
 
     class ids:
         button_group = lambda aio_id: {
-            'component': 'ProjectCommandsAIO',
+            'component': 'NodeControlAIO',
             'subcomponent': 'btn_group',
             'aio_id': aio_id
         }
         alert = lambda aio_id: {
-            'component': 'ProjectCommandsAIO',
+            'component': 'NodeControlAIO',
             'subcomponent': 'alert',
             'aio_id': aio_id
         }
@@ -30,7 +30,7 @@ class ProjectCommandsAIO(html.Div):
     ids = ids
 
     def __init__(self, button_group, alert_props, aio_id: str = None):
-        """ProjectCommandsAIO is an All-in-One component that is composed
+        """NodeControlAIO is an All-in-One component that is composed
         of a parent `html.Div` with a `dbc.Stack` and a `dbc.Alert` as children.
 
         - `button_group` - The container of buttons used to build the project commands.
@@ -94,32 +94,32 @@ class ProjectCommandsAIO(html.Div):
     def run_command(action_requested, pathname):
         """This performs actions such as stopping, restarting, and shutting down on an instance of optiSlang when action is requested. A message with the status of the method execution and states of each button is updated on completion of the method."""
         project = DashClient[{{ cookiecutter.__solution_definition_name }}].get_project(pathname)
-        problem_setup_step = project.steps.problem_setup_step
-        problem_setup_step.selected_actor_from_command = problem_setup_step.selected_actor_from_treeview
+        monitoring_step = project.steps.monitoring_step
+        monitoring_step.selected_actor_from_command = monitoring_step.selected_actor_from_treeview
         ctx = callback_context
         if (ctx.triggered and action_requested):
             alert_status = {"alert-message": "", "alert-color": ""}
             try:
-                problem_setup_step.control_node_state()
-                command_execution_state = problem_setup_step.get_method_state("control_node_state").status
+                monitoring_step.control_node_state()
+                command_execution_state = monitoring_step.get_method_state("control_node_state").status
                 if command_execution_state == MethodStatus.Completed:
-                    alert_status["alert-message"] =  f"{problem_setup_step.selected_command.replace('_', ' ').title()} command completed successfully.",
+                    alert_status["alert-message"] =  f"{monitoring_step.selected_command.replace('_', ' ').title()} command completed successfully.",
                     alert_status["alert-color"] = "success"
             except Exception as e:
-                alert_status["alert-message"] = f"{problem_setup_step.selected_command.replace('_', ' ').title()} command failed. For details, review the logs.",
+                alert_status["alert-message"] = f"{monitoring_step.selected_command.replace('_', ' ').title()} command failed. For details, review the logs.",
                 alert_status["alert-color"] = "warning"
         else:
             raise PreventUpdate
-        if problem_setup_step.actor_uid:
-            problem_setup_step.actor_command_execution_status = alert_status
-            problem_setup_step.project_command_execution_status = {"alert-message": "", "alert-color": ""}
-            btn_group_options = problem_setup_step.actor_btn_group_options
+        if monitoring_step.actor_uid:
+            monitoring_step.actor_command_execution_status = alert_status
+            monitoring_step.project_command_execution_status = {"alert-message": "", "alert-color": ""}
+            btn_group_options = monitoring_step.actor_btn_group_options
         else:
-            problem_setup_step.project_command_execution_status = alert_status
-            problem_setup_step.actor_command_execution_status = {"alert-message": "", "alert-color": ""}
-            btn_group_options = problem_setup_step.project_btn_group_options
-        problem_setup_step.commands_locked = False
-        return alert_status["alert-message"], alert_status["alert-color"], bool(alert_status["alert-message"]), ButtonGroup(options=btn_group_options, disabled=problem_setup_step.commands_locked).buttons
+            monitoring_step.project_command_execution_status = alert_status
+            monitoring_step.actor_command_execution_status = {"alert-message": "", "alert-color": ""}
+            btn_group_options = monitoring_step.project_btn_group_options
+        monitoring_step.commands_locked = False
+        return alert_status["alert-message"], alert_status["alert-color"], bool(alert_status["alert-message"]), ButtonGroup(options=btn_group_options, disabled=monitoring_step.commands_locked).buttons
 
     @callback(
         Output("action-requested", "children"),
@@ -132,8 +132,8 @@ class ProjectCommandsAIO(html.Div):
     def set_selected_command_and_disable_buttons(n_clicks_actions, button_states, pathname):
         """This disables all project and actor command buttons on click of a button and sends and returns a bool for action requested."""
         project = DashClient[{{ cookiecutter.__solution_definition_name }}].get_project(pathname)
-        problem_setup_step = project.steps.problem_setup_step
-        problem_setup_step.selected_actor_from_command = problem_setup_step.selected_actor_from_treeview
+        monitoring_step = project.steps.monitoring_step
+        monitoring_step.selected_actor_from_command = monitoring_step.selected_actor_from_treeview
         ctx = callback_context
         if (
             ctx.triggered
@@ -141,9 +141,9 @@ class ProjectCommandsAIO(html.Div):
         ):
             triggered_button = callback_context.triggered[0]["prop_id"].split(".")[0]
             action = json.loads(triggered_button)["action"]
-            problem_setup_step.selected_command = action
+            monitoring_step.selected_command = action
             disable_buttons = [True] * len(button_states)
-            problem_setup_step.commands_locked = True
+            monitoring_step.commands_locked = True
         else:
             raise PreventUpdate
         return True, disable_buttons

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/project_information_table.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/project_information_table.py
@@ -7,7 +7,7 @@ import uuid
 from dash_extensions.enrich import html, dash_table
 
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.definition import {{ cookiecutter.__solution_definition_name }}
-from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.problem_setup_step import ProblemSetupStep
+from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.monitoring_step import MonitoringStep
 
 
 class ProjectInformationTableAIO(html.Div):
@@ -21,11 +21,11 @@ class ProjectInformationTableAIO(html.Div):
 
     ids = ids
 
-    def __init__(self, problem_setup_step: ProblemSetupStep, datatable_props: dict = None, interval_props: dict = None, aio_id: str = None):
+    def __init__(self, monitoring_step: MonitoringStep, datatable_props: dict = None, interval_props: dict = None, aio_id: str = None):
         """ProjectInformationTableAIO is an All-in-One component that is composed
         of a parent `html.Div` with a `dcc.Interval` and a `dash_table.DataTable` as children.
 
-        - `problem_setup_step` - The StepModel object of the problem setup step.
+        - `monitoring_step` - The StepModel object of the monitoring step.
         - `datatable_props` - A dictionary of properties passed into the dash_table.DataTable component.
         - `interval_props` - A dictionary of properties passed into the dcc.Interval component.
         - `aio_id` - The All-in-One component ID used to generate the table components's dictionary IDs.
@@ -34,7 +34,7 @@ class ProjectInformationTableAIO(html.Div):
         if aio_id is None:
             aio_id = str(uuid.uuid4())
 
-        data = self.get_data(problem_setup_step)
+        data = self.get_data(monitoring_step)
 
         datatable_props = {
             "data": data.to_dict('records'),
@@ -73,7 +73,7 @@ class ProjectInformationTableAIO(html.Div):
             )
         ])
 
-    def get_data(self, problem_setup_step) -> pd.DataFrame:
+    def get_data(self, monitoring_step: MonitoringStep) -> pd.DataFrame:
 
         project_summary_data = {
             "column_a": [
@@ -100,15 +100,15 @@ class ProjectInformationTableAIO(html.Div):
             ],
         }
 
-        if problem_setup_step.project_status_info:
+        if monitoring_step.project_status_info:
             project_summary_data["column_b"] = [
-                problem_setup_step.project_status_info["projects"][0]["state"],
-                problem_setup_step.project_status_info["projects"][0]["project_id"],
-                problem_setup_step.project_status_info["projects"][0]["name"],
-                problem_setup_step.project_status_info["projects"][0]["machine"],
-                problem_setup_step.project_status_info["projects"][0]["location"],
-                problem_setup_step.project_status_info["projects"][0]["working_dir"],
-                problem_setup_step.project_status_info["projects"][0]["user"],
+                monitoring_step.project_status_info["projects"][0]["state"],
+                monitoring_step.project_status_info["projects"][0]["project_id"],
+                monitoring_step.project_status_info["projects"][0]["name"],
+                monitoring_step.project_status_info["projects"][0]["machine"],
+                monitoring_step.project_status_info["projects"][0]["location"],
+                monitoring_step.project_status_info["projects"][0]["working_dir"],
+                monitoring_step.project_status_info["projects"][0]["user"],
                 "",
                 "",
             ]

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/project_information_table.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/project_information_table.py
@@ -1,6 +1,7 @@
 # ©2023, ANSYS Inc. Unauthorized use, distribution or duplication is prohibited.
 
 import dash_bootstrap_components as dbc
+import json
 import pandas as pd
 import uuid
 
@@ -75,6 +76,8 @@ class ProjectInformationTableAIO(html.Div):
 
     def get_data(self, monitoring_step: MonitoringStep) -> pd.DataFrame:
 
+        project_status_info = json.loads(monitoring_step.project_status_info_file.read_text())
+
         project_summary_data = {
             "column_a": [
                 "State",
@@ -100,15 +103,15 @@ class ProjectInformationTableAIO(html.Div):
             ],
         }
 
-        if monitoring_step.project_status_info:
+        if project_status_info:
             project_summary_data["column_b"] = [
-                monitoring_step.project_status_info["projects"][0]["state"],
-                monitoring_step.project_status_info["projects"][0]["project_id"],
-                monitoring_step.project_status_info["projects"][0]["name"],
-                monitoring_step.project_status_info["projects"][0]["machine"],
-                monitoring_step.project_status_info["projects"][0]["location"],
-                monitoring_step.project_status_info["projects"][0]["working_dir"],
-                monitoring_step.project_status_info["projects"][0]["user"],
+                project_status_info["projects"][0]["state"],
+                project_status_info["projects"][0]["project_id"],
+                project_status_info["projects"][0]["name"],
+                project_status_info["projects"][0]["machine"],
+                project_status_info["projects"][0]["location"],
+                project_status_info["projects"][0]["working_dir"],
+                project_status_info["projects"][0]["user"],
                 "",
                 "",
             ]

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/service_table.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/service_table.py
@@ -6,7 +6,7 @@ import uuid
 
 from dash_extensions.enrich import html, dash_table
 
-from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.problem_setup_step import ProblemSetupStep
+from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.monitoring_step import MonitoringStep
 
 
 class ServiceTableAIO(html.Div):
@@ -20,11 +20,11 @@ class ServiceTableAIO(html.Div):
 
     ids = ids
 
-    def __init__(self, problem_setup_step: ProblemSetupStep, datatable_props: dict = None, aio_id: str = None):
+    def __init__(self, monitoring_step: MonitoringStep, datatable_props: dict = None, aio_id: str = None):
         """ServiceTableAIO is an All-in-One component that is composed
         of a parent `html.Div` with a `dcc.Interval` and a `dash_table.DataTable` as children.
 
-        - `problem_setup_step` - The StepModel object of the problem setup step.
+        - `monitoring_step` - The StepModel object of the monitoring step.
         - `datatable_props` - A dictionary of properties passed into the dash_table.DataTable component.
         - `interval_props` - A dictionary of properties passed into the dcc.Interval component.
         - `aio_id` - The All-in-One component ID used to generate the table components's dictionary IDs.
@@ -33,7 +33,7 @@ class ServiceTableAIO(html.Div):
         if aio_id is None:
             aio_id = str(uuid.uuid4())
 
-        data = self.get_data(problem_setup_step)
+        data = self.get_data(monitoring_step)
 
         datatable_props = {
             "data": data.to_dict('records'),
@@ -72,7 +72,7 @@ class ServiceTableAIO(html.Div):
             )
         ])
 
-    def get_data(self, problem_setup_step) -> pd.DataFrame:
+    def get_data(self, monitoring_step: MonitoringStep) -> pd.DataFrame:
 
         data = {
             "column_a": [
@@ -86,8 +86,8 @@ class ServiceTableAIO(html.Div):
         }
 
         data["column_b"] = [
-            problem_setup_step.tcp_server_host,
-            problem_setup_step.tcp_server_port,
+            monitoring_step.tcp_server_host,
+            monitoring_step.tcp_server_port,
         ]
 
         return pd.DataFrame(data)

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/service_table.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/service_table.py
@@ -6,7 +6,7 @@ import uuid
 
 from dash_extensions.enrich import html, dash_table
 
-from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.monitoring_step import MonitoringStep
+from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.problem_setup_step import ProblemSetupStep
 
 
 class ServiceTableAIO(html.Div):
@@ -20,11 +20,11 @@ class ServiceTableAIO(html.Div):
 
     ids = ids
 
-    def __init__(self, monitoring_step: MonitoringStep, datatable_props: dict = None, aio_id: str = None):
+    def __init__(self, problem_setup_step: ProblemSetupStep, datatable_props: dict = None, aio_id: str = None):
         """ServiceTableAIO is an All-in-One component that is composed
         of a parent `html.Div` with a `dcc.Interval` and a `dash_table.DataTable` as children.
 
-        - `monitoring_step` - The StepModel object of the monitoring step.
+        - `problem_setup_step` - The StepModel object of the problem setup step.
         - `datatable_props` - A dictionary of properties passed into the dash_table.DataTable component.
         - `interval_props` - A dictionary of properties passed into the dcc.Interval component.
         - `aio_id` - The All-in-One component ID used to generate the table components's dictionary IDs.
@@ -33,7 +33,7 @@ class ServiceTableAIO(html.Div):
         if aio_id is None:
             aio_id = str(uuid.uuid4())
 
-        data = self.get_data(monitoring_step)
+        data = self.get_data(problem_setup_step)
 
         datatable_props = {
             "data": data.to_dict('records'),
@@ -72,7 +72,7 @@ class ServiceTableAIO(html.Div):
             )
         ])
 
-    def get_data(self, monitoring_step: MonitoringStep) -> pd.DataFrame:
+    def get_data(self, problem_setup_step: ProblemSetupStep) -> pd.DataFrame:
 
         data = {
             "column_a": [
@@ -86,8 +86,8 @@ class ServiceTableAIO(html.Div):
         }
 
         data["column_b"] = [
-            monitoring_step.tcp_server_host,
-            monitoring_step.tcp_server_port,
+            problem_setup_step.tcp_server_host,
+            problem_setup_step.tcp_server_port,
         ]
 
         return pd.DataFrame(data)

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/system_files.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/system_files.py
@@ -6,7 +6,7 @@ import uuid
 from dash_extensions.enrich import html, dcc
 
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.definition import {{ cookiecutter.__solution_definition_name }}
-from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.problem_setup_step import ProblemSetupStep
+from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.monitoring_step import MonitoringStep
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.utilities.common_functions import (
     remove_key_from_dictionaries,
     sort_dict_by_ordered_keys,
@@ -39,11 +39,11 @@ class SystemFilesAIO(html.Div):
 
     ids = ids
 
-    def __init__(self, problem_setup_step: ProblemSetupStep, aio_id: str = None):
+    def __init__(self, monitoring_step: MonitoringStep, aio_id: str = None):
         """SystemFilesAIO is an All-in-One component that is composed
         of a parent `html.Div` with a `dcc.Interval` and a `dash_table.DataTable` as children.
 
-        - `problem_setup_step` - The StepModel object of the problem setup step.
+        - `monitoring_step` - The StepModel object of the monitoring step.
         - `datatable_props` - A dictionary of properties passed into the dash_table.DataTable component.
         - `interval_props` - A dictionary of properties passed into the dcc.Interval component.
         - `aio_id` - The All-in-One component ID used to generate the table components's dictionary IDs.

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/pages/monitoring_page.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/pages/monitoring_page.py
@@ -12,6 +12,7 @@ from ansys.saf.glow.client.dashclient import DashClient, callback
 
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.definition import {{ cookiecutter.__solution_definition_name }}
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.problem_setup_step import ProblemSetupStep
+from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.monitoring_step import MonitoringStep
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.views import (
     design_table_view,
     project_summary_view,
@@ -24,9 +25,9 @@ from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.views import (
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.utilities.common_functions import extract_dict_by_key, update_list_of_tabs
 
 
-def layout(problem_setup_step: ProblemSetupStep) -> html.Div:
+def layout(problem_setup_step: ProblemSetupStep, monitoring_step: MonitoringStep) -> html.Div:
 
-    actor_info = extract_dict_by_key(problem_setup_step.project_tree, "uid", problem_setup_step.selected_actor_from_treeview, expect_unique=True, return_index=False)
+    actor_info = extract_dict_by_key(problem_setup_step.project_tree, "uid", monitoring_step.selected_actor_from_treeview, expect_unique=True, return_index=False)
     list_of_tabs = update_list_of_tabs(actor_info)
 
     return html.Div(
@@ -35,7 +36,7 @@ def layout(problem_setup_step: ProblemSetupStep) -> html.Div:
                 [
                     daq.BooleanSwitch(
                         id='activate_auto_update',
-                        on=problem_setup_step.auto_update_activated,
+                        on=monitoring_step.auto_update_activated,
                         color="#FFB71B",
                         className="ms-auto",
                     ),
@@ -70,22 +71,22 @@ def update_page_content(active_tab, pathname):
     """Update the page content according to the selected tab."""
 
     project = DashClient[{{ cookiecutter.__solution_definition_name }}].get_project(pathname)
-    problem_setup_step = project.steps.problem_setup_step
+    monitoring_step = project.steps.monitoring_step
 
     if active_tab == "project_summary_tab":
-        return project_summary_view.layout(problem_setup_step)
+        return project_summary_view.layout(monitoring_step)
     elif active_tab == "summary_tab":
-        return summary_view.layout(problem_setup_step)
+        return summary_view.layout(monitoring_step)
     elif active_tab == "result_files_tab":
-        return result_files_view.layout(problem_setup_step)
+        return result_files_view.layout(monitoring_step)
     elif active_tab == "scenery_tab":
-        return scenery_view.layout(problem_setup_step)
+        return scenery_view.layout(monitoring_step)
     elif active_tab == "design_table_tab":
-        return design_table_view.layout(problem_setup_step)
+        return design_table_view.layout(monitoring_step)
     elif active_tab == "visualization_tab":
-        return visualization_view.layout(problem_setup_step)
+        return visualization_view.layout(monitoring_step)
     elif active_tab == "status_overview_tab":
-        return status_overview_view.layout(problem_setup_step)
+        return status_overview_view.layout(monitoring_step)
 
 
 @callback(
@@ -97,8 +98,8 @@ def update_page_content(active_tab, pathname):
 def activate_auto_update(on, pathname):
 
     project = DashClient[{{ cookiecutter.__solution_definition_name }}].get_project(pathname)
-    problem_setup_step = project.steps.problem_setup_step
+    monitoring_step = project.steps.monitoring_step
 
-    problem_setup_step.auto_update_activated = on
+    monitoring_step.auto_update_activated = on
 
     raise PreventUpdate

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/pages/monitoring_page.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/pages/monitoring_page.py
@@ -71,12 +71,13 @@ def update_page_content(active_tab, pathname):
     """Update the page content according to the selected tab."""
 
     project = DashClient[{{ cookiecutter.__solution_definition_name }}].get_project(pathname)
+    problem_setup_step = project.steps.problem_setup_step
     monitoring_step = project.steps.monitoring_step
 
     if active_tab == "project_summary_tab":
-        return project_summary_view.layout(monitoring_step)
+        return project_summary_view.layout(problem_setup_step, monitoring_step)
     elif active_tab == "summary_tab":
-        return summary_view.layout(monitoring_step)
+        return summary_view.layout(problem_setup_step, monitoring_step)
     elif active_tab == "result_files_tab":
         return result_files_view.layout(monitoring_step)
     elif active_tab == "scenery_tab":

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/pages/page.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/pages/page.py
@@ -48,7 +48,6 @@ layout = html.Div(
 )
 def initialization(pathname):
     """Run methods to initialize the solution."""
-
     project = DashClient[{{ cookiecutter.__solution_definition_name }}].get_project(pathname)
 
     if not project.steps.problem_setup_step.project_initialized:
@@ -73,7 +72,6 @@ def initialization(pathname):
 )
 def update_progress_bar(n_intervals, pathname):
     """Track status of solution initialization."""
-
     project = DashClient[{{ cookiecutter.__solution_definition_name }}].get_project(pathname)
     problem_setup_step = project.steps.problem_setup_step
 
@@ -120,7 +118,6 @@ def update_progress_bar(n_intervals, pathname):
 )
 def display_page_layout(pathname, trigger_layout_display):
     """Display page layout."""
-
     project = DashClient[{{ cookiecutter.__solution_definition_name }}].get_project(pathname)
     problem_setup_step = project.steps.problem_setup_step
 
@@ -162,7 +159,7 @@ def display_page_layout(pathname, trigger_layout_display):
                                 n_clicks = 0,
                                 href=DashClient.get_portal_ui_url(),
                                 style = {"background-color": "rgba(0, 0, 0, 1)", "border-color": "rgba(0, 0, 0, 1)"},
-                            )
+                            ) if DashClient.get_portal_ui_url() else []
                         ],
                     ),
                 ],
@@ -250,7 +247,6 @@ def display_page_layout(pathname, trigger_layout_display):
 )
 def display_body_content(value, pathname, trigger_body_display):
     """Display body content."""
-
     project = DashClient[{{ cookiecutter.__solution_definition_name }}].get_project(pathname)
     problem_setup_step = project.steps.problem_setup_step
     monitoring_step = project.steps.monitoring_step
@@ -279,7 +275,6 @@ def display_body_content(value, pathname, trigger_body_display):
 )
 def display_tree_view(pathname, trigger_treeview_display):
     """Display treeview with all project nodes."""
-
     project = DashClient[{{ cookiecutter.__solution_definition_name }}].get_project(pathname)
     problem_setup_step = project.steps.problem_setup_step
 
@@ -298,7 +293,7 @@ def display_tree_view(pathname, trigger_treeview_display):
     prevent_initial_call=True,
 )
 def display_optislang_logs(n_clicks, pathname, is_open):
-
+    """Display optiSLang logs."""
     project = DashClient[{{ cookiecutter.__solution_definition_name }}].get_project(pathname)
     monitoring_step = project.steps.monitoring_step
 
@@ -319,7 +314,6 @@ def display_optislang_logs(n_clicks, pathname, is_open):
 )
 def open_in_browser(n_clicks, pathname):
     """Open the Portal UI in browser view."""
-
     portal_ui_url = DashClient.get_portal_ui_url()
     webbrowser.open_new(portal_ui_url)
 

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/pages/page.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/pages/page.py
@@ -252,8 +252,8 @@ def display_body_content(value, pathname, trigger_body_display):
     """Display body content."""
 
     project = DashClient[{{ cookiecutter.__solution_definition_name }}].get_project(pathname)
-
     problem_setup_step = project.steps.problem_setup_step
+    monitoring_step = project.steps.monitoring_step
 
     if problem_setup_step.project_initialized:
         triggered_id = callback_context.triggered[0]["prop_id"].split(".")[0]
@@ -265,8 +265,8 @@ def display_body_content(value, pathname, trigger_body_display):
             elif value == "problem_setup_step":
                 page_layout = problem_setup_page.layout(problem_setup_step)
             else:
-                problem_setup_step.selected_actor_from_treeview = extract_dict_by_key(problem_setup_step.treeview_items, "key", value, expect_unique=True, return_index=False)["uid"]
-                page_layout = monitoring_page.layout(problem_setup_step)
+                monitoring_step.selected_actor_from_treeview = extract_dict_by_key(problem_setup_step.treeview_items, "key", value, expect_unique=True, return_index=False)["uid"]
+                page_layout = monitoring_page.layout(problem_setup_step, monitoring_step)
             return page_layout
     else:
         raise PreventUpdate
@@ -300,13 +300,13 @@ def display_tree_view(pathname, trigger_treeview_display):
 def display_optislang_logs(n_clicks, pathname, is_open):
 
     project = DashClient[{{ cookiecutter.__solution_definition_name }}].get_project(pathname)
-    problem_setup_step = project.steps.problem_setup_step
+    monitoring_step = project.steps.monitoring_step
 
     if not n_clicks:
         # Button has never been clicked
         return None, False
 
-    table = LogsTable(problem_setup_step.optislang_logs)
+    table = LogsTable(monitoring_step.optislang_logs)
 
     return table.render(), not is_open
 

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/pages/page.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/pages/page.py
@@ -258,12 +258,12 @@ def display_body_content(value, pathname, trigger_body_display):
     if problem_setup_step.project_initialized:
         triggered_id = callback_context.triggered[0]["prop_id"].split(".")[0]
         if triggered_id == "url" or triggered_id == "trigger_body_display" or trigger_body_display and len(triggered_id) == 0:
-            return problem_setup_page.layout(problem_setup_step)
+            return problem_setup_page.layout(problem_setup_step, monitoring_step)
         if triggered_id == "navigation_tree":
             if value is None:
                 page_layout = html.H1("Welcome!")
             elif value == "problem_setup_step":
-                page_layout = problem_setup_page.layout(problem_setup_step)
+                page_layout = problem_setup_page.layout(problem_setup_step, monitoring_step)
             else:
                 monitoring_step.selected_actor_from_treeview = extract_dict_by_key(problem_setup_step.treeview_items, "key", value, expect_unique=True, return_index=False)["uid"]
                 page_layout = monitoring_page.layout(problem_setup_step, monitoring_step)

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/pages/problem_setup_page.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/pages/problem_setup_page.py
@@ -15,10 +15,11 @@ from ansys.solutions.optislang.frontend_components.load_sections import to_dash_
 
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.definition import {{ cookiecutter.__solution_definition_name }}
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.problem_setup_step import ProblemSetupStep
+from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.monitoring_step import MonitoringStep
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.utilities.common_functions import check_empty_strings, update_alerts
 
 
-def layout(problem_setup_step: ProblemSetupStep) -> html.Div:
+def layout(problem_setup_step: ProblemSetupStep, monitoring_step: MonitoringStep) -> html.Div:
     """Layout of the problem setup step."""
 
     project_properties_sections = to_dash_sections(
@@ -56,7 +57,7 @@ def layout(problem_setup_step: ProblemSetupStep) -> html.Div:
                     dbc.Col(
                         [
                             dbc.Stack(
-                                update_alerts(problem_setup_step),
+                                update_alerts(problem_setup_step, monitoring_step),
                                 id="alert_messages",
                                 direction="horizontal",
                                 gap=3,
@@ -182,7 +183,7 @@ def start_analysis(n_clicks, pathname):
             return (
                 True,
                 problem_setup_step.treeview_items,
-                update_alerts(problem_setup_step),
+                update_alerts(problem_setup_step, monitoring_step),
                 True,
                 True,
                 to_dash_sections(
@@ -194,7 +195,7 @@ def start_analysis(n_clicks, pathname):
             return (
                 True,
                 problem_setup_step.treeview_items,
-                update_alerts(problem_setup_step),
+                update_alerts(problem_setup_step, monitoring_step),
                 True,
                 False,
                 to_dash_sections(
@@ -217,9 +218,10 @@ def update_alert_messages(n_intervals, n_clicks, pathname):
 
     project = DashClient[{{ cookiecutter.__solution_definition_name }}].get_project(pathname)
     problem_setup_step = project.steps.problem_setup_step
+    monitoring_step = project.steps.monitoring_step
 
     if problem_setup_step.ansys_ecosystem_ready:
-        return update_alerts(problem_setup_step)
+        return update_alerts(problem_setup_step, monitoring_step)
     else:
         raise PreventUpdate
 

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/design_table_view.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/design_table_view.py
@@ -8,11 +8,11 @@ from dash_extensions.enrich import html, Input, Output, State, dcc
 from ansys.saf.glow.client.dashclient import DashClient, callback
 
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.definition import {{ cookiecutter.__solution_definition_name }}
-from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.problem_setup_step import ProblemSetupStep
+from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.monitoring_step import MonitoringStep
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.design_table import DesignTableAIO
 
 
-def layout(problem_setup_step: ProblemSetupStep) -> html.Div:
+def layout(monitoring_step: MonitoringStep) -> html.Div:
     """Layout of the design table view."""
 
     return html.Div(
@@ -20,14 +20,14 @@ def layout(problem_setup_step: ProblemSetupStep) -> html.Div:
             html.Br(),
             dbc.Row(
                 [
-                    dbc.Col(html.Div(DesignTableAIO(problem_setup_step), id="design_table"), width=12),
+                    dbc.Col(html.Div(DesignTableAIO(monitoring_step), id="design_table"), width=12),
                 ]
             ),
             dcc.Interval(
                 id="design_table_auto_update",
-                interval=problem_setup_step.auto_update_frequency,  # in milliseconds
+                interval=monitoring_step.auto_update_frequency,  # in milliseconds
                 n_intervals=0,
-                disabled=False if problem_setup_step.auto_update_activated else True
+                disabled=False if monitoring_step.auto_update_activated else True
             ),
         ]
     )
@@ -53,6 +53,6 @@ def activate_auto_update(on, pathname):
 def update_view(n_intervals, pathname):
 
     project = DashClient[{{ cookiecutter.__solution_definition_name }}].get_project(pathname)
-    problem_setup_step = project.steps.problem_setup_step
+    monitoring_step = project.steps.monitoring_step
 
-    return DesignTableAIO(problem_setup_step)
+    return DesignTableAIO(monitoring_step)

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/project_summary_view.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/project_summary_view.py
@@ -9,29 +9,29 @@ from dash_extensions.enrich import html, Input, Output, State, dcc
 from ansys.saf.glow.client.dashclient import DashClient, callback
 
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.definition import {{ cookiecutter.__solution_definition_name }}
-from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.problem_setup_step import ProblemSetupStep
+from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.monitoring_step import MonitoringStep
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.commands import ProjectCommandsAIO
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.project_information_table import ProjectInformationTableAIO
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.service_table import ServiceTableAIO
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.button_group import ButtonGroup
 
 
-def layout(problem_setup_step: ProblemSetupStep) -> html.Div:
+def layout(monitoring_step: MonitoringStep) -> html.Div:
     """Layout of the project summary view."""
     alert_props = {
-        "children":problem_setup_step.project_command_execution_status["alert-message"],
-        "color":problem_setup_step.project_command_execution_status["alert-color"],
-        "is_open": bool(problem_setup_step.project_command_execution_status["alert-message"]),
+        "children":monitoring_step.project_command_execution_status["alert-message"],
+        "color":monitoring_step.project_command_execution_status["alert-color"],
+        "is_open": bool(monitoring_step.project_command_execution_status["alert-message"]),
     }
-    button_group = ButtonGroup(options=problem_setup_step.project_btn_group_options, disabled=problem_setup_step.commands_locked).buttons
+    button_group = ButtonGroup(options=monitoring_step.project_btn_group_options, disabled=monitoring_step.commands_locked).buttons
 
     return html.Div(
         [
             html.Br(),
             dbc.Row(
                 [
-                    dbc.Col(html.Div(ProjectInformationTableAIO(problem_setup_step), id="project_information_table"), width=8),
-                    dbc.Col(html.Div(ServiceTableAIO(problem_setup_step), id="service_table"), width=4),
+                    dbc.Col(html.Div(ProjectInformationTableAIO(monitoring_step), id="project_information_table"), width=8),
+                    dbc.Col(html.Div(ServiceTableAIO(monitoring_step), id="service_table"), width=4),
                 ]
             ),
             html.Br(),
@@ -42,9 +42,9 @@ def layout(problem_setup_step: ProblemSetupStep) -> html.Div:
             ),
             dcc.Interval(
                 id="project_summary_auto_update",
-                interval=problem_setup_step.auto_update_frequency,  # in milliseconds
+                interval=monitoring_step.auto_update_frequency,  # in milliseconds
                 n_intervals=0,
-                disabled=False if problem_setup_step.auto_update_activated else True
+                disabled=False if monitoring_step.auto_update_activated else True
             ),
         ]
     )
@@ -70,6 +70,6 @@ def activate_auto_update(on, pathname):
 def update_view(n_intervals, pathname):
 
     project = DashClient[{{ cookiecutter.__solution_definition_name }}].get_project(pathname)
-    problem_setup_step = project.steps.problem_setup_step
+    monitoring_step = project.steps.monitoring_step
 
-    return ProjectInformationTableAIO(problem_setup_step)
+    return ProjectInformationTableAIO(monitoring_step)

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/project_summary_view.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/project_summary_view.py
@@ -10,7 +10,7 @@ from ansys.saf.glow.client.dashclient import DashClient, callback
 
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.definition import {{ cookiecutter.__solution_definition_name }}
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.monitoring_step import MonitoringStep
-from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.commands import ProjectCommandsAIO
+from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.node_control import NodeControlAIO
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.project_information_table import ProjectInformationTableAIO
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.service_table import ServiceTableAIO
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.button_group import ButtonGroup

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/project_summary_view.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/project_summary_view.py
@@ -9,6 +9,7 @@ from dash_extensions.enrich import html, Input, Output, State, dcc
 from ansys.saf.glow.client.dashclient import DashClient, callback
 
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.definition import {{ cookiecutter.__solution_definition_name }}
+from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.problem_setup_step import ProblemSetupStep
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.monitoring_step import MonitoringStep
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.node_control import NodeControlAIO
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.project_information_table import ProjectInformationTableAIO
@@ -16,7 +17,7 @@ from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.servi
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.button_group import ButtonGroup
 
 
-def layout(monitoring_step: MonitoringStep) -> html.Div:
+def layout(problem_setup_step: ProblemSetupStep, monitoring_step: MonitoringStep) -> html.Div:
     """Layout of the project summary view."""
     alert_props = {
         "children":monitoring_step.project_command_execution_status["alert-message"],
@@ -31,7 +32,7 @@ def layout(monitoring_step: MonitoringStep) -> html.Div:
             dbc.Row(
                 [
                     dbc.Col(html.Div(ProjectInformationTableAIO(monitoring_step), id="project_information_table"), width=8),
-                    dbc.Col(html.Div(ServiceTableAIO(monitoring_step), id="service_table"), width=4),
+                    dbc.Col(html.Div(ServiceTableAIO(problem_setup_step), id="service_table"), width=4),
                 ]
             ),
             html.Br(),

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/project_summary_view.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/project_summary_view.py
@@ -37,7 +37,7 @@ def layout(monitoring_step: MonitoringStep) -> html.Div:
             html.Br(),
             dbc.Row(
                 [
-                    dbc.Col(ProjectCommandsAIO(button_group, alert_props, "project-commands"), width=12),
+                    dbc.Col(NodeControlAIO(button_group, alert_props, "project-commands"), width=12),
                 ]
             ),
             dcc.Interval(

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/result_files_view.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/result_files_view.py
@@ -4,10 +4,10 @@
 
 from dash_extensions.enrich import html
 
-from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.problem_setup_step import ProblemSetupStep
+from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.monitoring_step import MonitoringStep
 
 
-def layout(problem_setup_step: ProblemSetupStep) -> html.Div:
+def layout(monitoring_step: MonitoringStep) -> html.Div:
     """Layout of the result files view."""
 
     return html.Div([])

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/scenery_view.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/scenery_view.py
@@ -6,13 +6,13 @@ import optislang_dash_lib
 
 from dash_extensions.enrich import html
 
-from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.problem_setup_step import ProblemSetupStep
+from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.monitoring_step import MonitoringStep
 
 
-def layout(problem_setup_step: ProblemSetupStep) -> html.Div:
+def layout(monitoring_step: MonitoringStep) -> html.Div:
     """Layout of the scenery view."""
 
-    if problem_setup_step.project_status_info:
+    if monitoring_step.project_status_info:
         return html.Div(
             [
                 html.Br(),
@@ -20,7 +20,7 @@ def layout(problem_setup_step: ProblemSetupStep) -> html.Div:
                     [
                         optislang_dash_lib.SceneryComponent(
                             id="input",
-                            project_state=problem_setup_step.project_status_info,
+                            project_state=monitoring_step.project_status_info,
                         ),
                     ]
                 ),

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/scenery_view.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/scenery_view.py
@@ -2,6 +2,7 @@
 
 """Frontend of the scenery view."""
 
+import json
 import optislang_dash_lib
 
 from dash_extensions.enrich import html
@@ -12,7 +13,9 @@ from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.monitoring
 def layout(monitoring_step: MonitoringStep) -> html.Div:
     """Layout of the scenery view."""
 
-    if monitoring_step.project_status_info:
+    project_status_info = json.loads(monitoring_step.project_status_info_file.read_text())
+
+    if project_status_info:
         return html.Div(
             [
                 html.Br(),
@@ -20,7 +23,7 @@ def layout(monitoring_step: MonitoringStep) -> html.Div:
                     [
                         optislang_dash_lib.SceneryComponent(
                             id="input",
-                            project_state=monitoring_step.project_status_info,
+                            project_state=project_status_info,
                         ),
                     ]
                 ),

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/status_overview_view.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/status_overview_view.py
@@ -6,19 +6,19 @@ import optislang_dash_lib
 
 from dash_extensions.enrich import html
 
-from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.problem_setup_step import ProblemSetupStep
+from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.monitoring_step import MonitoringStep
 
 
-def layout(problem_setup_step: ProblemSetupStep) -> html.Div:
+def layout(monitoring_step: MonitoringStep) -> html.Div:
     """Layout of the status overview view."""
 
-    if problem_setup_step.project_status_info:
+    if monitoring_step.project_status_info:
         return html.Div(
             id="node-status-view",
             children=[
                 optislang_dash_lib.Nodestatusviewcomponent(
                     id="node-status-view-component",
-                    project_state=problem_setup_step.project_status_info,
+                    project_state=monitoring_step.project_status_info,
                 ),
             ],
         )

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/status_overview_view.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/status_overview_view.py
@@ -2,6 +2,7 @@
 
 """Frontend of the node status overview view."""
 
+import json
 import optislang_dash_lib
 
 from dash_extensions.enrich import html
@@ -12,13 +13,15 @@ from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.monitoring
 def layout(monitoring_step: MonitoringStep) -> html.Div:
     """Layout of the status overview view."""
 
-    if monitoring_step.project_status_info:
+    project_status_info = json.loads(monitoring_step.project_status_info_file.read_text())
+
+    if project_status_info:
         return html.Div(
             id="node-status-view",
             children=[
                 optislang_dash_lib.Nodestatusviewcomponent(
                     id="node-status-view-component",
-                    project_state=monitoring_step.project_status_info,
+                    project_state=project_status_info,
                 ),
             ],
         )

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/summary_view.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/summary_view.py
@@ -40,7 +40,7 @@ def layout(monitoring_step: MonitoringStep) -> html.Div:
         html.Br(),
         dbc.Row(
             [
-                dbc.Col(ProjectCommandsAIO(button_group, alert_props, "actor-commands"), width=12),
+                dbc.Col(NodeControlAIO(button_group, alert_props, "actor-commands"), width=12),
             ]
         ),
     ]

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/summary_view.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/summary_view.py
@@ -12,7 +12,7 @@ from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.definition
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.monitoring_step import MonitoringStep
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.actor_information_table import ActorInformationTableAIO
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.button_group import ButtonGroup
-from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.commands import ProjectCommandsAIO
+from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.node_control import NodeControlAIO
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.system_files import SystemFilesAIO
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.actor_logs_table import ActorLogsTableAIO
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.actor_statistics_table import ActorStatisticsTableAIO

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/summary_view.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/summary_view.py
@@ -9,7 +9,7 @@ from dash_extensions.enrich import html, Input, Output, State, dcc
 from ansys.saf.glow.client.dashclient import DashClient, callback
 
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.definition import {{ cookiecutter.__solution_definition_name }}
-from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.problem_setup_step import ProblemSetupStep
+from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.monitoring_step import MonitoringStep
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.actor_information_table import ActorInformationTableAIO
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.button_group import ButtonGroup
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.commands import ProjectCommandsAIO
@@ -19,22 +19,22 @@ from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.actor
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.utilities.common_functions import extract_dict_by_key
 
 
-def layout(problem_setup_step: ProblemSetupStep) -> html.Div:
+def layout(monitoring_step: MonitoringStep) -> html.Div:
     """Layout of the summary view."""
 
     alert_props = {
-        "children": problem_setup_step.actor_command_execution_status["alert-message"],
-        "color": problem_setup_step.actor_command_execution_status["alert-color"],
-        "is_open": bool(problem_setup_step.actor_command_execution_status["alert-message"]),
+        "children": monitoring_step.actor_command_execution_status["alert-message"],
+        "color": monitoring_step.actor_command_execution_status["alert-color"],
+        "is_open": bool(monitoring_step.actor_command_execution_status["alert-message"]),
     }
-    button_group = ButtonGroup(options=problem_setup_step.actor_btn_group_options, disabled=problem_setup_step.commands_locked).buttons
-    actor_info = extract_dict_by_key(problem_setup_step.project_tree, "uid", problem_setup_step.selected_actor_from_treeview, expect_unique=True, return_index=False)
+    button_group = ButtonGroup(options=monitoring_step.actor_btn_group_options, disabled=monitoring_step.commands_locked).buttons
+    actor_info = extract_dict_by_key(monitoring_step.project_tree, "uid", monitoring_step.selected_actor_from_treeview, expect_unique=True, return_index=False)
 
     content = [
         html.Br(),
         dbc.Row(
             [
-                dbc.Col(html.Div(ActorInformationTableAIO(problem_setup_step), id="actor_information_table"), width=12),
+                dbc.Col(html.Div(ActorInformationTableAIO(monitoring_step), id="actor_information_table"), width=12),
             ]
         ),
         html.Br(),
@@ -52,7 +52,7 @@ def layout(problem_setup_step: ProblemSetupStep) -> html.Div:
                     html.Br(),
                     dbc.Row(
                         [
-                            dbc.Col(SystemFilesAIO(problem_setup_step, aio_id="system_files"), width=12),
+                            dbc.Col(SystemFilesAIO(monitoring_step, aio_id="system_files"), width=12),
                         ]
                     ),
                 ]
@@ -63,20 +63,20 @@ def layout(problem_setup_step: ProblemSetupStep) -> html.Div:
                 html.Br(),
                 dbc.Row(
                     [
-                        dbc.Col(html.Div(ActorLogsTableAIO(problem_setup_step), id="actor_logs_table"), width=12),
+                        dbc.Col(html.Div(ActorLogsTableAIO(monitoring_step), id="actor_logs_table"), width=12),
                     ]
                 ),
                 html.Br(),
                 dbc.Row(
                     [
-                        dbc.Col(html.Div(ActorStatisticsTableAIO(problem_setup_step), id="actor_statistics_table"), width=12),
+                        dbc.Col(html.Div(ActorStatisticsTableAIO(monitoring_step), id="actor_statistics_table"), width=12),
                     ]
                 ),
                 dcc.Interval(
                     id="summary_auto_update",
-                    interval=problem_setup_step.auto_update_frequency,  # in milliseconds
+                    interval=monitoring_step.auto_update_frequency,  # in milliseconds
                     n_intervals=0,
-                    disabled=False if problem_setup_step.auto_update_activated else True
+                    disabled=False if monitoring_step.auto_update_activated else True
                 ),
             ]
         )
@@ -106,10 +106,10 @@ def activate_auto_update(on, pathname):
 def update_view(n_intervals, pathname):
 
     project = DashClient[{{ cookiecutter.__solution_definition_name }}].get_project(pathname)
-    problem_setup_step = project.steps.problem_setup_step
+    monitoring_step = project.steps.monitoring_step
 
     return (
-        ActorInformationTableAIO(problem_setup_step),
-        ActorLogsTableAIO(problem_setup_step),
-        ActorStatisticsTableAIO(problem_setup_step)
+        ActorInformationTableAIO(monitoring_step),
+        ActorLogsTableAIO(monitoring_step),
+        ActorStatisticsTableAIO(monitoring_step)
     )

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/summary_view.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/summary_view.py
@@ -9,6 +9,7 @@ from dash_extensions.enrich import html, Input, Output, State, dcc
 from ansys.saf.glow.client.dashclient import DashClient, callback
 
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.definition import {{ cookiecutter.__solution_definition_name }}
+from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.problem_setup_step import ProblemSetupStep
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.monitoring_step import MonitoringStep
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.actor_information_table import ActorInformationTableAIO
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.button_group import ButtonGroup
@@ -19,7 +20,7 @@ from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.ui.components.actor
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.utilities.common_functions import extract_dict_by_key
 
 
-def layout(monitoring_step: MonitoringStep) -> html.Div:
+def layout(problem_setup_step: ProblemSetupStep, monitoring_step: MonitoringStep) -> html.Div:
     """Layout of the summary view."""
 
     alert_props = {
@@ -28,7 +29,7 @@ def layout(monitoring_step: MonitoringStep) -> html.Div:
         "is_open": bool(monitoring_step.actor_command_execution_status["alert-message"]),
     }
     button_group = ButtonGroup(options=monitoring_step.actor_btn_group_options, disabled=monitoring_step.commands_locked).buttons
-    actor_info = extract_dict_by_key(monitoring_step.project_tree, "uid", monitoring_step.selected_actor_from_treeview, expect_unique=True, return_index=False)
+    actor_info = extract_dict_by_key(problem_setup_step.project_tree, "uid", monitoring_step.selected_actor_from_treeview, expect_unique=True, return_index=False)
 
     content = [
         html.Br(),

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/visualization_view.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/visualization_view.py
@@ -2,6 +2,7 @@
 
 """Frontend of the visualization view."""
 
+import json
 import optislang_dash_lib
 
 from dash_extensions.enrich import html
@@ -12,11 +13,13 @@ from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.monitoring
 def layout(monitoring_step: MonitoringStep) -> html.Div:
     """Layout of the visualization view."""
 
+    project_status_info = json.loads(monitoring_step.project_status_info_file.read_text())
+
     return html.Div(
         [
             optislang_dash_lib.VisualizationComponent(
                 id="visualization-component",
-                project_state=monitoring_step.project_status_info,
+                project_state=project_status_info,
                 system_id=monitoring_step.selected_actor_from_treeview,
                 state_idx=0,
             ),

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/visualization_view.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/visualization_view.py
@@ -6,18 +6,18 @@ import optislang_dash_lib
 
 from dash_extensions.enrich import html
 
-from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.problem_setup_step import ProblemSetupStep
+from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.monitoring_step import MonitoringStep
 
 
-def layout(problem_setup_step: ProblemSetupStep) -> html.Div:
+def layout(monitoring_step: MonitoringStep) -> html.Div:
     """Layout of the visualization view."""
 
     return html.Div(
         [
             optislang_dash_lib.VisualizationComponent(
                 id="visualization-component",
-                project_state=problem_setup_step.project_status_info,
-                system_id=problem_setup_step.selected_actor_from_treeview,
+                project_state=monitoring_step.project_status_info,
+                system_id=monitoring_step.selected_actor_from_treeview,
                 state_idx=0,
             ),
         ]

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/utilities/common_functions.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/utilities/common_functions.py
@@ -242,7 +242,7 @@ def update_placeholders(ui_values: list, placeholders: dict) -> dict:
     return updated_dict
 
 
-def update_alerts(problem_setup_step) -> list:
+def update_alerts(problem_setup_step, monitoring_step) -> list:
     """Update all Alerts."""
 
     alerts = []
@@ -273,10 +273,10 @@ def update_alerts(problem_setup_step) -> list:
         )
 
     # optiSLang solve alert
-    if problem_setup_step.project_state in PROJECT_STATES.keys():
-        solve_message, solve_color = PROJECT_STATES[problem_setup_step.project_state]["alert"], PROJECT_STATES[problem_setup_step.project_state]["color"]
+    if monitoring_step.project_state in PROJECT_STATES.keys():
+        solve_message, solve_color = PROJECT_STATES[monitoring_step.project_state]["alert"], PROJECT_STATES[monitoring_step.project_state]["color"]
     else:
-        raise ValueError(f"Unknown optiSLang state: {problem_setup_step.project_state}.")
+        raise ValueError(f"Unknown optiSLang state: {monitoring_step.project_state}.")
 
     alerts.append(
         html.Div(

--- a/tests/tests_templates/test_python_templates.py
+++ b/tests/tests_templates/test_python_templates.py
@@ -368,6 +368,7 @@ OSL_SOLUTION_STRUCTURE = [
     f"src/ansys/solutions/{OSL_SOLUTION_VARS['__solution_name_slug']}/model/assets/README.md",
     f"src/ansys/solutions/{OSL_SOLUTION_VARS['__solution_name_slug']}/solution/definition.py",
     f"src/ansys/solutions/{OSL_SOLUTION_VARS['__solution_name_slug']}/solution/problem_setup_step.py",
+    f"src/ansys/solutions/{OSL_SOLUTION_VARS['__solution_name_slug']}/solution/monitoring_step.py",
     f"src/ansys/solutions/{OSL_SOLUTION_VARS['__solution_name_slug']}/ui/assets/css/style.css",
     f"src/ansys/solutions/{OSL_SOLUTION_VARS['__solution_name_slug']}/ui/assets/images/README.md",
     f"src/ansys/solutions/{OSL_SOLUTION_VARS['__solution_name_slug']}/ui/assets/logos/ansys-solutions-horizontal-logo.png",

--- a/tests/tests_templates/test_python_templates.py
+++ b/tests/tests_templates/test_python_templates.py
@@ -377,7 +377,7 @@ OSL_SOLUTION_STRUCTURE = [
     f"src/ansys/solutions/{OSL_SOLUTION_VARS['__solution_name_slug']}/ui/components/actor_logs_table.py",
     f"src/ansys/solutions/{OSL_SOLUTION_VARS['__solution_name_slug']}/ui/components/actor_statistics_table.py",
     f"src/ansys/solutions/{OSL_SOLUTION_VARS['__solution_name_slug']}/ui/components/button_group.py",
-    f"src/ansys/solutions/{OSL_SOLUTION_VARS['__solution_name_slug']}/ui/components/commands.py",
+    f"src/ansys/solutions/{OSL_SOLUTION_VARS['__solution_name_slug']}/ui/components/node_control.py",
     f"src/ansys/solutions/{OSL_SOLUTION_VARS['__solution_name_slug']}/ui/components/design_table.py",
     f"src/ansys/solutions/{OSL_SOLUTION_VARS['__solution_name_slug']}/ui/components/logs_table.py",
     f"src/ansys/solutions/{OSL_SOLUTION_VARS['__solution_name_slug']}/ui/components/project_information_table.py",


### PR DESCRIPTION
- [x] Expect a monitoring step to handle all fields and transaction methods related to monitoring.
- [x] Expect a separation of optiSLang project start and monitoring.
   - [x] Expect the start to be handle in the problem_setup_step
   - [x] Expect the monitoring to be handle in the monitoring_step
- [x] Expect the responses of the TCP servers to be dumped in json files instead of being saved in the database
- [x] Expect the back to projects button to be disabled when the user starts the solution with --project