### PR TITLE
Prevent ConflictError that occurs when updating UI placeholder values too quickly

### DIFF
--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/pages/page.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/pages/page.py
@@ -245,14 +245,14 @@ def display_body_content(value, pathname, trigger_body_display):
                 )
             )
         if triggered_id == "url" or triggered_id == "trigger_body_display" or trigger_body_display and len(triggered_id) == 0:
-            page_layout = problem_setup_page.layout(problem_setup_step, monitoring_step)
+            page_layout = problem_setup_page.layout(problem_setup_step)
             focusRequested = ""
         if triggered_id == "navigation_tree":
             focusRequested = value["id"]
             if value["id"] is None:
                 page_layout = html.H1("Welcome!")
             elif value["id"] == "problem_setup_step":
-                page_layout = problem_setup_page.layout(problem_setup_step, monitoring_step)
+                page_layout = problem_setup_page.layout(problem_setup_step)
             else:
                 # Get project data
                 project_data = json.loads(monitoring_step.project_data_dump.read_text())

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/pages/problem_setup_page.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/pages/problem_setup_page.py
@@ -15,13 +15,13 @@ from ansys.solutions.optislang.frontend_components.load_sections import to_dash_
 
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.definition import {{ cookiecutter.__solution_definition_name }}
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.problem_setup_step import ProblemSetupStep
-from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.solution.monitoring_step import MonitoringStep
 from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.utilities.common_functions import check_empty_strings
 
 
-def layout(problem_setup_step: ProblemSetupStep, monitoring_step: MonitoringStep) -> html.Div:
+def layout(problem_setup_step: ProblemSetupStep) -> html.Div:
     """Layout of the problem setup step."""
-
+    if problem_setup_step.ui_placeholders and not problem_setup_step.project_locked:
+        problem_setup_step.update_osl_placeholders_with_ui_values()
     project_properties_sections = to_dash_sections(
             problem_setup_step.placeholders, problem_setup_step.registered_files, problem_setup_step.project_locked
         )
@@ -236,6 +236,7 @@ def initialize_dictionary_of_ui_placeholders(n_clicks, data, ids, input_file_ids
             ui_data.update({input_file_ids[index]["placeholder"]: ""})
 
         problem_setup_step.ui_placeholders = ui_data
+        problem_setup_step.update_osl_placeholders_with_ui_values()
         return problem_setup_step.analysis_locked
     else:
         return no_update
@@ -297,9 +298,6 @@ def update_ui_placeholders(value, id, pathname):
         else:
             ui_data.update({name: value})
         problem_setup_step.ui_placeholders = ui_data
-        while problem_setup_step.get_method_state("update_osl_placeholders_with_ui_values").status == MethodStatus.Running: # current workaround to avoid raising ConflictError: {"detail":"update_osl_placeholders_with_ui_values is already running"}
-            time.sleep(0.1)
-        problem_setup_step.update_osl_placeholders_with_ui_values()
         return no_update
 
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactoring
- [ ] User story with back-end changes
- [ ] User story with front-end changes
- [x] Bug Fix
- [ ] Documentation Update

## Description
The workaround implemented to resolve this [issue ](https://github.com/Solution-Applications/solution-enablement-product-management/issues/546) is not working - see reported bug [here](https://github.com/orgs/Solution-Applications/saml/initiate?return_to=https%3A%2F%2Fgithub.com%2FSolution-Applications%2Fsolution-enablement-product-management%2Fissues%2F617). The issue is that we have one transaction method that is triggered every time theres a change in the UI - this is done to update a step field to persist data in the ui. If this method is triggered too quickly (under1-4 sec), a conflict error is raised saying this method is already running. The workaround was to get the state of the method and force it to complete before re-triggering the method. However, this does not appear to work. 

This PR resolves this issue by only updating the step field on page load. This still persists the data in the ui. The only effect is that the page takes a few more seconds to load as it needs this method to complete before rendering the layout. 

## Related Tickets

- Fixes problem seen in: https://github.com/Solution-Applications/solution-enablement-product-management/issues/617

##  Screenshots, Recordings


## QA Instructions,

1. Checkout branch associated to this PR
2. In a .venv run: flit install to gather latest changes made to the osl-solution template
3. Create a new osl-solution using overview_project.owa: ansys-templates new solution -f owa -a <path-to-owa-file>
4. In your terminal, set your current directory to the directory of the new solution.
5.  Setup the python virtual environment by running: python setup_environment.py -d run
6.  Run the solution and create a new project
7. Change values in the UI.
8. Go back to project portal.
9. Click on modified project and check that the data is persisted.