### PR TITLE
Fix badge url for pyansys-advanced template

### DIFF
--- a/src/ansys/templates/python/pyansys_advanced/{{cookiecutter.__project_name_slug}}/README.rst
+++ b/src/ansys/templates/python/pyansys_advanced/{{cookiecutter.__project_name_slug}}/README.rst
@@ -14,12 +14,12 @@ Py{{ cookiecutter.product_name }} {{ cookiecutter.library_name }}
    :target: https://pypi.org/project/{{cookiecutter.__project_name_slug}}
    :alt: PyPI
 
-.. |codecov| image:: https://codecov.io/gh/pyansys/{{cookiecutter.__project_name_slug}}/branch/main/graph/badge.svg
-   :target: https://codecov.io/gh/pyansys/{{cookiecutter.__project_name_slug}}
+.. |codecov| image:: https://codecov.io/gh/ansys/{{cookiecutter.__project_name_slug}}/branch/main/graph/badge.svg
+   :target: https://codecov.io/gh/ansys/{{cookiecutter.__project_name_slug}}
    :alt: Codecov
 
-.. |GH-CI| image:: https://github.com/pyansys/{{cookiecutter.__project_name_slug}}/actions/workflows/ci_cd.yml/badge.svg
-   :target: https://github.com/pyansys/{{cookiecutter.__project_name_slug}}/actions/workflows/ci_cd.yml
+.. |GH-CI| image:: https://github.com/ansys/{{cookiecutter.__project_name_slug}}/actions/workflows/ci_cd.yml/badge.svg
+   :target: https://github.com/ansys/{{cookiecutter.__project_name_slug}}/actions/workflows/ci_cd.yml
    :alt: GH-CI
 
 .. |MIT| image:: https://img.shields.io/badge/License-MIT-yellow.svg


### PR DESCRIPTION
Fixes #379

This fixes the badges url for pyansys-advanced template when its being generated.
- code-coverage
- GH-CI

But I think each of the demo branches need changes

[pyansys-advanced using flit](https://github.com/ansys/ansys-templates/tree/demo/pyansys-advanced-flit)
[pyansys-advanced using poetry](https://github.com/ansys/ansys-templates/tree/demo/pyansys-advanced-poetry)
[pyansys-advanced using setuptools](https://github.com/ansys/ansys-templates/tree/demo/pyansys-advanced-setuptools)


