### PR TITLE
Rmorin/fix method already running issue

### DIFF
--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/solution/problem_setup_step.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/solution/problem_setup_step.py
@@ -174,6 +174,7 @@ class ProblemSetupStep(StepModel):
             upload=["placeholders", "registered_files", "settings", "parameter_manager", "criteria"],
         )
     )
+    @long_running
     def update_osl_placeholders_with_ui_values(self) -> None:
         """Update placeholders with values selected by the user in the UI."""
         properties = apply_placeholders_to_properties_file(self.ui_placeholders, self.properties_file.path)

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/pages/page.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/pages/page.py
@@ -248,7 +248,7 @@ def display_body_content(value, trigger_body_display, selectedItemIds, pathname)
             if value["id"] is None:
                 page_layout = html.H1("Welcome!")
             elif value["id"] == "problem_setup_step":
-                if "problem_setup_step" not in last_selected_item:
+                if "problem_setup_step" not in last_selected_item: # this is to minimize the number of times the page is reloaded. I noticed issues with the creation of the layout when the page is reloaded too many times closely together
                     page_layout = problem_setup_page.layout(problem_setup_step)
                     last_selected_item = ["problem_setup_step"]
                 else:

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/pages/problem_setup_page.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/pages/problem_setup_page.py
@@ -19,6 +19,8 @@ from ansys.solutions.{{ cookiecutter.__solution_name_slug }}.utilities.common_fu
 def layout(problem_setup_step: ProblemSetupStep) -> html.Div:
     """Layout of the problem setup step."""
     if problem_setup_step.ui_placeholders and not problem_setup_step.project_locked:
+        while problem_setup_step.get_long_running_method_state("update_osl_placeholders_with_ui_values").status == MethodStatus.Running: # current workaround to avoid raising ConflictError: {"detail":"update_osl_placeholders_with_ui_values is already running"} # current workaround to avoid raising ConflictError: {"detail":"update_osl_placeholders_with_ui_values is already running"}
+            time.sleep(0.1)
         problem_setup_step.update_osl_placeholders_with_ui_values()
     project_properties_sections = to_dash_sections(
             problem_setup_step.placeholders, problem_setup_step.registered_files, problem_setup_step.project_locked
@@ -469,7 +471,7 @@ def update_start_designs_table(n_clicks_add, n_clicks_del, disabled_states, row_
         ui_data.update({"StartDesigns": new_designs})
 
         problem_setup_step.ui_placeholders = ui_data
-        while problem_setup_step.get_method_state("update_osl_placeholders_with_ui_values").status == MethodStatus.Running: # current workaround to avoid raising ConflictError: {"detail":"update_osl_placeholders_with_ui_values is already running"}
+        while problem_setup_step.get_long_running_method_state("update_osl_placeholders_with_ui_values").status == MethodStatus.Running: # current workaround to avoid raising ConflictError: {"detail":"update_osl_placeholders_with_ui_values is already running"}
             time.sleep(0.1)
         problem_setup_step.update_osl_placeholders_with_ui_values()
 


### PR DESCRIPTION
Changes in this PR include:
- Linked callbacks to ensure each function is triggered in the right order
- Switch``update_osl_placeholders_with_ui_values`` method to long running method to ensure method completes before re-starting to avoid conflict error that occurs when this method is triggered sequentially as a normal sync method. This provides a  fix for: https://github.com/Solution-Applications/solution-enablement-product-management/issues/738
