### PR TITLE
Update design table to persist page numbers

### DIFF
--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/solution/monitoring_step.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/solution/monitoring_step.py
@@ -32,6 +32,7 @@ class MonitoringStep(StepModel):
     auto_update_activated: bool = True
     actor_uid: Optional[str] = None
     selected_page: int = 0
+    design_table_selected_page: int = 0
     project_command_execution_status: dict = {"alert-message": "", "alert-color": "info"}
     actor_command_execution_status: dict = {"alert-message": "", "alert-color": "info"}
     project_btn_group_options: List = [

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/actor_logs_table.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/actor_logs_table.py
@@ -23,6 +23,7 @@ class ActorLogsTableAIO(html.Div):
         of a `dash_table.DataTable` component.
 
         - `data` - Data to be displayed in the datatable component.
+        - `store_value` - Page number to be persisted in the pagination.
         - `aio_id` - The All-in-One component ID used to generate the table components's dictionary IDs.
         """
 

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/design_table.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/design_table.py
@@ -20,11 +20,12 @@ class DesignTableAIO(html.Div):
 
     ids = ids
 
-    def __init__(self, data: dict, aio_id: str = None):
+    def __init__(self, data: dict, store_value: int= None, aio_id: str = None):
         """DesignTableAIO is an All-in-One component that is composed
         of a `dash_table.DataTable` component.
 
         - `data` - Data to be displayed in the datatable component.
+        - `store_value` - Page number to be persisted in the pagination.
         - `aio_id` - The All-in-One component ID used to generate the table components's dictionary IDs.
         """
 
@@ -69,6 +70,7 @@ class DesignTableAIO(html.Div):
                 },
             ],
             "style_as_list_view": True,
+            "page_current": store_value,
             "style_cell": {
                 "textAlign": "center",
                 "font_family": "Roboto",

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/design_table.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/design_table.py
@@ -38,7 +38,7 @@ class DesignTableAIO(html.Div):
             "data": data.to_dict('records'),
             "columns": [{"name": i, "id": i, "type": "text"} for i in data.columns],
             "editable": True, # user can select and copy data
-            "fixed_rows": {"data": 0},
+            "fixed_rows": {"headers": True},
             "fixed_columns": {"data": 0},
             "style_header": {
                 "textAlign": "center",

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/design_table.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/components/design_table.py
@@ -38,7 +38,7 @@ class DesignTableAIO(html.Div):
             "data": data.to_dict('records'),
             "columns": [{"name": i, "id": i, "type": "text"} for i in data.columns],
             "editable": True, # user can select and copy data
-            "fixed_rows": {"headers": True},
+            "fixed_rows": {"data": 0},
             "fixed_columns": {"data": 0},
             "style_header": {
                 "textAlign": "center",

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/design_table_view.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/design_table_view.py
@@ -55,8 +55,7 @@ def layout(problem_setup_step: ProblemSetupStep, monitoring_step: MonitoringStep
                 interval=5000,  # in milliseconds
                 n_intervals=0,
                 disabled=False if monitoring_step.auto_update_activated else True
-            ),
-            html.Div(id="dummy-table-output", style= {'display': 'none'}),
+            )
         ]
     )
 
@@ -152,7 +151,6 @@ def update_view(n_intervals, pathname):
 
 
 @callback(
-    Output("dummy-table-output", 'children'),
     Input(DesignTableAIO.ids.datatable("design_table_logs"), "page_current"),
     State("url", "pathname"),
     prevent_initial_call=True,
@@ -165,4 +163,3 @@ def update_table(page_current, pathname):
     # Get monitoring step
     monitoring_step = project.steps.monitoring_step
     monitoring_step.design_table_selected_page = page_current
-    return f"Dummy output updated {page_current}"

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/design_table_view.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/design_table_view.py
@@ -162,7 +162,7 @@ def update_view(n_intervals, pathname):
 def update_table(page_current, pathname):
 
     # Get project
-    project = DashClient[Oscillator_CalibrationSolution].get_project(pathname)
+    project = DashClient[{{ cookiecutter.__solution_definition_name }}].get_project(pathname)
 
     # Get monitoring step
     monitoring_step = project.steps.monitoring_step

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/design_table_view.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/design_table_view.py
@@ -105,7 +105,6 @@ def display_alerts(n_intervals, pathname):
 
 @callback(
     Output("design_table", "children"),
-    Output(DesignTableAIO.ids.datatable("design_table_logs"), "store_value"),
     Output("selected_state_dropdown", "options"),
     Output("selected_state_dropdown", "value"),
     Output("design_table_auto_update", "disabled"),
@@ -140,8 +139,7 @@ def update_view(n_intervals, pathname):
                 if len(project_data.get("actors").get(monitoring_step.selected_actor_from_treeview).get("states_ids")):
                     monitoring_step.selected_state_id = project_data.get("actors").get(monitoring_step.selected_actor_from_treeview).get("states_ids")[0]
             return (
-                DesignTableAIO(design_table_data),
-                monitoring_step.design_table_selected_page,
+                DesignTableAIO(design_table_data,monitoring_step.design_table_selected_page),
                 project_data.get("actors").get(monitoring_step.selected_actor_from_treeview).get("states_ids"),
                 monitoring_step.selected_state_id,
                 True if problem_setup_step.osl_project_state in ["NOT STARTED", "FINISHED", "ABORTED"] else False

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/summary_view.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/src/ansys/solutions/{{cookiecutter.__solution_name_slug}}/ui/views/summary_view.py
@@ -113,8 +113,7 @@ def layout(problem_setup_step: ProblemSetupStep, monitoring_step: MonitoringStep
             interval=monitoring_step.auto_update_frequency,  # in milliseconds
             n_intervals=0,
             disabled=False if monitoring_step.auto_update_activated else True
-        ),
-        html.Div(id="dummy-output", style= {'display': 'block'}),
+        )
     ]
 
     # Build layout
@@ -224,7 +223,6 @@ def update_view(n_intervals, pathname):
 
 
 @callback(
-    Output("dummy-output", 'children'),
     Input(ActorLogsTableAIO.ids.datatable("actor_logs_table"), "page_current"),
     State("url", "pathname"),
     prevent_initial_call=True,
@@ -237,4 +235,3 @@ def update_table(page_current, pathname):
     # Get monitoring step
     monitoring_step = project.steps.monitoring_step
     monitoring_step.selected_page = page_current
-    return f"Dummy output updated {page_current}"


### PR DESCRIPTION
The PR has following changes:
* Design table AIO component updated to receive page number
* Additional callback to pass the page number to the design table