### PR TITLE
tweak: use open instead of your_browser_name

### DIFF
--- a/src/ansys/templates/python/pyansys/{{cookiecutter.__project_name_slug}}/README.rst
+++ b/src/ansys/templates/python/pyansys/{{cookiecutter.__project_name_slug}}/README.rst
@@ -99,7 +99,7 @@ For building documentation, you can either run the usual rules provided in the
     make -C doc/ html
 
     # subsequently open the documentation with (under Linux):
-    your_browser_name doc/html/index.html
+    open doc/html/index.html
 
 Distributing
 ------------

--- a/src/ansys/templates/python/pyansys_advanced/{{cookiecutter.__project_name_slug}}/README.rst
+++ b/src/ansys/templates/python/pyansys_advanced/{{cookiecutter.__project_name_slug}}/README.rst
@@ -178,13 +178,13 @@ For building documentation, you can either run the usual rules provided in the
 
 .. code:: bash
 
-    make -C doc/ html && your_browser_name doc/html/index.html
+    make -C doc/ html && open doc/html/index.html
 
 However, the recommended way of checking documentation integrity is using:
 
 .. code:: bash
 
-    tox -e doc && your_browser_name .tox/doc_out/index.html
+    tox -e doc && open .tox/doc_out/index.html
 
 
 Distributing

--- a/src/ansys/templates/python/pybasic/{{cookiecutter.__project_name_slug}}/README.rst
+++ b/src/ansys/templates/python/pybasic/{{cookiecutter.__project_name_slug}}/README.rst
@@ -97,7 +97,7 @@ For building documentation, you can either run the usual rules provided in the
     make -C doc/ html
 
     # optionally view the generated documentation (on linux) with
-    your_browser_name doc/html/index.html
+    open doc/html/index.html
 
 
 Distributing


### PR DESCRIPTION
The open command will use the default system browser to open the file https://linux.die.net/man/1/open