### PR TITLE
fix: Use HardLink instead of SymbolicLink

### DIFF
--- a/src/ansys/templates/python/solution/{{cookiecutter.__project_name_slug}}/setup_environment.py
+++ b/src/ansys/templates/python/solution/{{cookiecutter.__project_name_slug}}/setup_environment.py
@@ -605,7 +605,7 @@ def install_build_system(args: object) -> None:
                         "-Command",
                         "New-Item",
                         "-ItemType",
-                        "SymbolicLink",
+                        "HardLink",
                         "-Path",
                         f"'{DEPENDENCY_MANAGER_PATHS[sys.platform]['dep_bin_venv_path']}'",
                         "-Target",


### PR DESCRIPTION
Use HardLink instead of SymbolicLink for creating poetry.exe shortcut inside .venv/Scripts so as to  run the script without admin privilages