### PR TITLE
refactor: implementation for consuming internal or external artifactory

### DIFF
--- a/src/ansys/templates/python/solution/{{cookiecutter.__project_name_slug}}/pyproject.toml
+++ b/src/ansys/templates/python/solution/{{cookiecutter.__project_name_slug}}/pyproject.toml
@@ -42,10 +42,10 @@ priority = "primary"
 
 [tool.poetry.dependencies]
 python = ">=3.8, <3.11"
-ansys-dash-treeview = {version = "0.0.1.dev0", source = "solutions-private-pypi"}
-ansys-saf-portal = {version = "1.0rc3", source = "solutions-private-pypi"}
-ansys-saf-desktop = {version = "1.0rc3", source = "solutions-private-pypi"}
-ansys-solutions-dash-lib = {version = "^0.4", source = "solutions-private-pypi"}
+ansys-dash-treeview = {version = "0.0.1.dev0"}
+ansys-saf-portal = {version = "1.0rc3"}
+ansys-saf-desktop = {version = "1.0rc3"}
+ansys-solutions-dash-lib = {version = "^0.4"}
 {% if cookiecutter.with_dash_ui == "yes" %}
 dash = "^2.6"
 dash_bootstrap_components = "^1.2"


### PR DESCRIPTION
## Description
 Internal and External user must be able to consume internal or external artifactory respectively for downloading packages.

## QA Instructions, Screenshots, Recordings
Steps for internal users to consume packages:
1. Set either PYANSYS_PRIVATE_PYPI_PAT or SOLUTIONS_PRIVATE_PYPI_PAT environment variables.
2. Execute the setup_environment.py script.

Steps for external users to consume packages:
1. Generate a token at artifactory.ansys.com.
2. Set both ARTIFACTORY_PRIVATE_PYPI_PAT and ARTIFACTORY_PRIVATE_PYPI_USER environment variables.
3. Ensure VPN access is established.
4. Run the setup_environment.py script.