### PR TITLE
ci: make the e2e tests required

### DIFF
--- a/.github/workflows/solutions_ci.yml
+++ b/.github/workflows/solutions_ci.yml
@@ -46,7 +46,7 @@ jobs:
           curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{ secrets.WORKFLOW_TOKEN }}" \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/ansys/ansys-templates/statuses/${{ github.event.pull_request.head.sha }} \
           -d "{\"state\": \"Success\", \"context\": \" basic_solution_validation\", \"description\": \"Mock End-to-end tests with SAF Solution\" }"

--- a/.github/workflows/solutions_ci.yml
+++ b/.github/workflows/solutions_ci.yml
@@ -39,3 +39,14 @@ jobs:
           --repo "https://github.com/ansys-internal/solution-templates-end-to-end-testing" \
           --field ansys_templates_sha="${{ github.event.pull_request.head.sha }}" \
           --ref "refs/heads/main"
+
+      - name: mock e2e tests
+        if: ${{ needs.check-changes.outputs.solution-templates-changes == 'false' }}
+        run: |
+          curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.WORKFLOW_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/ansys/ansys-templates/statuses/${{ github.event.pull_request.base.sha }} \
+          -d "{\"state\": \"Success\", \"context\": \" basic_solution_validation\", \"description\": \"Mock End-to-end tests with SAF Solution\" }"

--- a/.github/workflows/solutions_ci.yml
+++ b/.github/workflows/solutions_ci.yml
@@ -1,8 +1,6 @@
 name: Trigger end-to-end tests for solution templates
 on:
   pull_request:
-    paths:
-      - 'src/ansys/templates/python/solution/**'
 
 jobs:
   check-changes:

--- a/.github/workflows/solutions_ci.yml
+++ b/.github/workflows/solutions_ci.yml
@@ -48,5 +48,5 @@ jobs:
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ secrets.WORKFLOW_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/ansys/ansys-templates/statuses/${{ github.event.pull_request.base.sha }} \
+          https://api.github.com/repos/ansys/ansys-templates/statuses/${{ github.event.pull_request.haed.sha }} \
           -d "{\"state\": \"Success\", \"context\": \" basic_solution_validation\", \"description\": \"Mock End-to-end tests with SAF Solution\" }"

--- a/.github/workflows/solutions_ci.yml
+++ b/.github/workflows/solutions_ci.yml
@@ -5,12 +5,33 @@ on:
       - 'src/ansys/templates/python/solution/**'
 
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      solution-templates-changes: ${{ steps.check-code-changes.outputs.solution-templates }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check code changes
+        uses: dorny/paths-filter@v3
+        id: check-code-changes
+        with:
+          base: ${{ inputs.head-reference }}
+          ref: ${{ inputs.base-reference }}
+          filters: |
+            solution-templates:
+              - 'src/ansys/templates/python/solution/**'
 
   solutions-e2e-tests:
     name: Trigger solutions e2e tests
+    needs: [check-changes]
     runs-on: ubuntu-latest
     steps:
       - name: github workflow dispatch
+        if: ${{ needs.check-changes.outputs.solution-templates-changes == 'true' }}
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.ANSYS_SOLUTIONS_E2E_TESTS }}

--- a/.github/workflows/solutions_ci.yml
+++ b/.github/workflows/solutions_ci.yml
@@ -48,5 +48,5 @@ jobs:
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ secrets.WORKFLOW_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/ansys/ansys-templates/statuses/${{ github.event.pull_request.haed.sha }} \
+          https://api.github.com/repos/ansys/ansys-templates/statuses/${{ github.event.pull_request.head.sha }} \
           -d "{\"state\": \"Success\", \"context\": \" basic_solution_validation\", \"description\": \"Mock End-to-end tests with SAF Solution\" }"

--- a/.github/workflows/solutions_ci.yml
+++ b/.github/workflows/solutions_ci.yml
@@ -49,4 +49,4 @@ jobs:
           -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/ansys/ansys-templates/statuses/${{ github.event.pull_request.head.sha }} \
-          -d "{\"state\": \"Success\", \"context\": \" basic_solution_validation\", \"description\": \"Mock End-to-end tests with SAF Solution\" }"
+          -d "{\"state\": \"success\", \"context\": \" basic_solution_validation\", \"description\": \"Mock End-to-end tests with SAF Solution\" }"


### PR DESCRIPTION
In this PR, I  adjusted the workflow to trigger the e2e tests.
We check if there is a change in `src/ansys/templates/python/solution/`.

When there is a change, the e2e tests are triggered and the following status is sent by the external workflow.
![image](https://github.com/ansys/ansys-templates/assets/78641481/b0c15e60-5249-4aca-a154-36bfac066747)

When there is no change, we mock the status as below.
![image](https://github.com/ansys/ansys-templates/assets/78641481/d4dd65eb-c921-4310-b6d9-3b6b3b767089).

This will allow to make the e2e tests required to merge the pull requests.
