### PR TITLE
doc: use imgconverter with imagemagick

### DIFF
--- a/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/.github/workflows/ci_cd.yml
+++ b/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/.github/workflows/ci_cd.yml
@@ -86,6 +86,7 @@ jobs:
       - uses: ansys/actions/doc-build@v5
         with:
           python-version: {{ '${{ env.MAIN_PYTHON_VERSION }}' }}
+          dependencies: "imagemagick"
 
   build-library:
     name: "Build library basic example"

--- a/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/doc/source/conf.py
+++ b/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/doc/source/conf.py
@@ -64,6 +64,7 @@ extensions = [
     "numpydoc",
     "sphinx.ext.intersphinx",
     "sphinx_copybutton",
+    "sphinx.ext.imgconverter",
 ]
 
 # Intersphinx mapping

--- a/src/ansys/templates/python/doc_project/{{cookiecutter.__project_name_slug}}/README.rst
+++ b/src/ansys/templates/python/doc_project/{{cookiecutter.__project_name_slug}}/README.rst
@@ -21,6 +21,21 @@ Previous command will run `pre-commit`_ for checking code quality.
 
 Documentation
 -------------
+
+Install imagemagick for image conversion:
+
+- Linux (Ubuntu)
+
+   .. code:: bash
+
+      sudo apt install imagemagick
+
+- Windows
+
+   .. code:: bash
+
+      winget install imagemagick
+
 Documentation can be rendered by running:
 
 .. code-block:: text

--- a/src/ansys/templates/python/pyansys/{{cookiecutter.__project_name_slug}}/README.rst
+++ b/src/ansys/templates/python/pyansys/{{cookiecutter.__project_name_slug}}/README.rst
@@ -90,6 +90,20 @@ environment, which is another reason to consider using `tox`_.
 Documentation
 -------------
 
+Install imagemagick for image conversion:
+
+- Linux (Ubuntu)
+
+   .. code:: bash
+
+      sudo apt install imagemagick
+
+- Windows
+
+   .. code:: bash
+
+      winget install imagemagick
+
 For building documentation, you can either run the usual rules provided in the
 `Sphinx`_ Makefile, such us:
 

--- a/src/ansys/templates/python/pyansys_advanced/{{cookiecutter.__project_name_slug}}/README.rst
+++ b/src/ansys/templates/python/pyansys_advanced/{{cookiecutter.__project_name_slug}}/README.rst
@@ -173,6 +173,20 @@ encouraged to install this tool via:
 Documentation
 -------------
 
+Install imagemagick for image conversion:
+
+- Linux (Ubuntu)
+
+   .. code:: bash
+
+      sudo apt install imagemagick
+
+- Windows
+
+   .. code:: bash
+
+      winget install imagemagick
+
 For building documentation, you can either run the usual rules provided in the
 `Sphinx`_ Makefile, such us:
 

--- a/src/ansys/templates/python/pybasic/{{cookiecutter.__project_name_slug}}/README.rst
+++ b/src/ansys/templates/python/pybasic/{{cookiecutter.__project_name_slug}}/README.rst
@@ -88,6 +88,20 @@ environment, which is another reason to use tools like `tox`_.
 Documentation
 -------------
 
+Install imagemagick for image conversion:
+
+- Linux (Ubuntu)
+
+   .. code:: bash
+
+      sudo apt install imagemagick
+
+- Windows
+
+   .. code:: bash
+
+      winget install imagemagick
+
 For building documentation, you can either run the usual rules provided in the
 `Sphinx`_ Makefile, such us:
 


### PR DESCRIPTION
Solves warnings when running  `poetry run -- make -C doc pdf` and for the CI `doc-build` step:
- 195c16b src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/doc/source/conf.py: extensions: add: "sphinx.ext.imgconverter"
```
.../README.rst:: WARNING: a suitable image for latex builder not found: ['image/svg+xml'] (https://img.shields.io/badge/Py-Ansys-ffc107.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAABDklEQVQ4jWNgoDfg5mD8vE7q/3bpVyskbW0sMRUwofHD7Dh5OBkZGBgW7/3W2tZpa2tLQEOyOzeEsfumlK2tbVpaGj4N6jIs1lpsDAwMJ278sveMY2BgCA0NFRISwqkhyQ1q/Nyd3zg4OBgYGNjZ2ePi4rB5loGBhZnhxTLJ/9ulv26Q4uVk1NXV/f///////69du4Zdg78lx//t0v+3S88rFISInD59GqIH2esIJ8G9O2/XVwhjzpw5EAam1xkkBJn/bJX+v1365hxxuCAfH9+3b9/+////48cPuNehNsS7cDEzMTAwMMzb+Q2u4dOnT2vWrMHu9ZtzxP9vl/69RVpCkBlZ3N7enoDXBwEAAA+YYitOilMVAAAAAElFTkSuQmCC)
.../README.rst:: WARNING: a suitable image for latex builder not found: ['image/svg+xml'] (https://codecov.io/gh/ansys/pysimba-library/branch/main/graph/badge.svg)
.../README.rst:: WARNING: a suitable image for latex builder not found: ['image/svg+xml'] (https://img.shields.io/badge/License-MIT-yellow.svg)
.../README.rst:: WARNING: a suitable image for latex builder not found: ['image/svg+xml'] (https://img.shields.io/badge/code%20style-black-000000.svg?style=flat)
```
- 198fe51 src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/.github/workflows/ci_cd.yml: doc-build: dependencies: "imagemagick"
```
WARNING: Unable to run the image conversion command 'magick'. 'sphinx.ext.imgconverter' requires ImageMagick by default. Ensure it is installed, or set the 'image_converter' option to a custom conversion command.
```

Note: installing imagemagick (`winget install imagemagick`, `sudo apt install imagemagick` ...) is then necessary to run `poetry run -- make -C doc pdf`:
- 1f6a0f0 src/ansys/templates/python/*/{{cookiecutter.__project_name_slug}}/README.rst: add: Install imagemagick for image conversion
