### PR TITLE
fix: run tests with specified python-version in CI

### DIFF
--- a/doc/changelog.d/480.fixed.md
+++ b/doc/changelog.d/480.fixed.md
@@ -1,0 +1,1 @@
+fix: run tests with specified python-version in CI

--- a/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/.github/workflows/ci_cd.yml
+++ b/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/.github/workflows/ci_cd.yml
@@ -93,6 +93,7 @@ jobs:
         uses: ansys/actions/tests-pytest@v6
         with:
           pytest-extra-args: "--cov=ansys --cov-report=term --cov-report=html:.cov/html"
+          python-version: {{ '${{ matrix.python-version }}' }}
 
       - name: Upload coverage results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Without that line all tests would run with python 3.10, no matter what's in the version matrix.

We noticed because we broke support for python 3.9 without the CI warning us.
Before, it's happy: https://github.com/ansys/pysimai/actions/runs/8881939762
After, it catches the issue: https://github.com/ansys/pysimai/actions/runs/9159532632