### PR TITLE
fix: change socio-economic to socioeconomic for codespell v2.3.0

### DIFF
--- a/doc/changelog.d/485.fixed.md
+++ b/doc/changelog.d/485.fixed.md
@@ -1,0 +1,1 @@
+fix: change socio-economic to socioeconomic for codespell v2.3.0

--- a/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/CODE_OF_CONDUCT.md
+++ b/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/CODE_OF_CONDUCT.md
@@ -7,7 +7,7 @@ contributors and maintainers pledge to making participation in our
 project and our community a harassment-free experience for everyone,
 regardless of age, body size, disability, ethnicity, sex
 characteristics, gender identity and expression, level of experience,
-education, socio-economic status, nationality, personal appearance,
+education, socioeconomic status, nationality, personal appearance,
 race, religion, or sexual identity and orientation.
 
 ## Our Standards


### PR DESCRIPTION
Codespell fails the "code style" job in v2.3.0 due to "socio-economic" in the CODE_OF_CONDUCT.md file. This PR changes the spelling to socioeconomic

Code style failure due to "socio-economic": https://github.com/ansys/pymechanical-embedding-examples/actions/runs/9260367397/job/25474002779
PR: https://github.com/ansys/pymechanical-embedding-examples/pull/198/files
