### PR TITLE
fix: suppress ``autosectionlabel`` warning for ``changelog`` file

### DIFF
--- a/doc/changelog.d/487.fixed.md
+++ b/doc/changelog.d/487.fixed.md
@@ -1,0 +1,1 @@
+fix: suppress ``autosectionlabel`` warning for ``changelog`` file

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -9,6 +9,44 @@ This document contains the release notes for the project.
 
 .. towncrier release notes start
 
+`3.0.0 <https://github.com/ansys/ansys-templates/releases/tag/v3.0.0>`_ - 2024-06-04
+====================================================================================
+
+Added
+^^^^^
+
+- feat: update CLI option for creating a Dash UI using AWC as well `#477 <https://github.com/ansys/ansys-templates/pull/477>`_
+
+
+Changed
+^^^^^^^
+
+- chore: update CHANGELOG for v2.1.0 `#473 <https://github.com/ansys/ansys-templates/pull/473>`_
+- maint: bump main dev version `#474 <https://github.com/ansys/ansys-templates/pull/474>`_
+- Maintenance/update solution template `#484 <https://github.com/ansys/ansys-templates/pull/484>`_
+
+
+Fixed
+^^^^^
+
+- fix: update pydocstyle in ``pyproject.toml`` file `#478 <https://github.com/ansys/ansys-templates/pull/478>`_
+- fix: run tests with specified python-version in CI `#480 <https://github.com/ansys/ansys-templates/pull/480>`_
+- fix: change socio-economic to socioeconomic for codespell v2.3.0 `#485 <https://github.com/ansys/ansys-templates/pull/485>`_
+
+
+Dependencies
+^^^^^^^^^^^^
+
+- Build(deps): Bump ansys-sphinx-theme from 0.14.1 to 0.16.0 `#475 <https://github.com/ansys/ansys-templates/pull/475>`_
+
+
+Miscellaneous
+^^^^^^^^^^^^^
+
+- Update ansys saf portal version `#472 <https://github.com/ansys/ansys-templates/pull/472>`_
+- feat: Add devcontainer config for codespaces `#481 <https://github.com/ansys/ansys-templates/pull/481>`_
+- docs: update authors file `#482 <https://github.com/ansys/ansys-templates/pull/482>`_
+
 `2.1.0 <https://github.com/ansys/ansys-templates/releases/tag/v2.1.0>`_ - 2024-05-14
 ====================================================================================
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -66,9 +66,12 @@ extensions = [
     "numpydoc",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
+    "sphinx.ext.autosectionlabel",
     "sphinx.ext.intersphinx",
     "sphinx_copybutton",
 ]
+
+suppress_warnings = ["autosectionlabel.changelog"]
 
 # Intersphinx mapping
 intersphinx_mapping = {

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -65,7 +65,6 @@ html_theme_options = {
 extensions = [
     "numpydoc",
     "sphinx.ext.autodoc",
-    "sphinx.ext.autosectionlabel",
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
     "sphinx_copybutton",

--- a/doc/source/templates.rst
+++ b/doc/source/templates.rst
@@ -58,7 +58,6 @@ capabilities and features of each template:
    for each one of the templates. Take a look to these branches for having a
    better idea on the final project layout.
 
-
 doc-project
 -----------
 This template renders a documentation project based on Sphinx. You can chose
@@ -80,7 +79,6 @@ To create a new project using this template by running:
 .. admonition:: Link to demo
 
     `ansys-templates/demo - doc-project <https://github.com/ansys/ansys-templates/tree/demo/doc-project>`_
-
 
 pybasic
 -------
@@ -106,8 +104,6 @@ To create a new project using this template by running:
 
     `ansys-templates/demo - pybasic <https://github.com/ansys/ansys-templates/tree/demo/pybasic>`_
 
-
-
 pyansys
 -------
 This template renders to a basic Python project compliant with the latest
@@ -131,7 +127,6 @@ To create a new project using this template, run:
 .. admonition:: Link to demo
 
     `ansys-templates/demo - pyansys <https://github.com/ansys/ansys-templates/tree/demo/pyansys>`_
-
 
 pyansys-advanced
 ----------------
@@ -162,7 +157,6 @@ To create a new project using this template, run:
     * `ansys-templates/demo - pyansys-advanced-poetry <https://github.com/ansys/ansys-templates/tree/demo/pyansys-advanced-poetry>`_
     * `ansys-templates/demo - pyansys-advanced-setuptools <https://github.com/ansys/ansys-templates/tree/demo/pyansys-advanced-setuptools>`_
 
-
 pyansys-openapi-client
 ----------------------
 Create an OpenAPI Client Package project compliant with PyAnsys guidelines.
@@ -182,7 +176,6 @@ To create a new project using this template, run:
 .. admonition:: Link to demo
 
     Demo unavailable at the moment.
-
 
 pyace
 -----
@@ -210,8 +203,6 @@ To create a new project using this template, run:
 
     `ansys-templates/demo - pyace-pkg <https://github.com/ansys/ansys-templates/tree/demo/pyace-pkg>`_
 
-
-
 pyace-fast
 ----------
 This template renders to a basic Python project compliant with the latest
@@ -237,8 +228,6 @@ To create a new project using this template, run:
 .. admonition:: Link to demo
 
     `ansys-templates/demo - pyace-fast <https://github.com/ansys/ansys-templates/tree/demo/pyace-fast>`_
-
-
 
 pyace-flask
 -----------
@@ -267,8 +256,6 @@ To create a new project using this template, run:
 
     `ansys-templates/demo - pyace-flask <https://github.com/ansys/ansys-templates/tree/demo/pyace-flask>`_
 
-
-
 pyace-grpc
 ----------
 This template renders to a basic Python project compliant with the latest
@@ -294,7 +281,6 @@ To create a new project using this template, run:
 .. admonition:: Link to demo
 
     `ansys-templates/demo - pyace-grpc <https://github.com/ansys/ansys-templates/tree/demo/pyace-grpc>`_
-
 
 solution
 --------

--- a/doc/source/templates.rst
+++ b/doc/source/templates.rst
@@ -58,6 +58,9 @@ capabilities and features of each template:
    for each one of the templates. Take a look to these branches for having a
    better idea on the final project layout.
 
+
+.. _doc-project:
+
 doc-project
 -----------
 This template renders a documentation project based on Sphinx. You can chose
@@ -80,6 +83,7 @@ To create a new project using this template by running:
 
     `ansys-templates/demo - doc-project <https://github.com/ansys/ansys-templates/tree/demo/doc-project>`_
 
+.. _pybasic:
 
 pybasic
 -------
@@ -106,6 +110,8 @@ To create a new project using this template by running:
     `ansys-templates/demo - pybasic <https://github.com/ansys/ansys-templates/tree/demo/pybasic>`_
 
 
+.. _pyansys:
+
 pyansys
 -------
 This template renders to a basic Python project compliant with the latest
@@ -130,6 +136,8 @@ To create a new project using this template, run:
 
     `ansys-templates/demo - pyansys <https://github.com/ansys/ansys-templates/tree/demo/pyansys>`_
 
+
+.. _pyansys-advanced:
 
 pyansys-advanced
 ----------------
@@ -161,6 +169,8 @@ To create a new project using this template, run:
     * `ansys-templates/demo - pyansys-advanced-setuptools <https://github.com/ansys/ansys-templates/tree/demo/pyansys-advanced-setuptools>`_
 
 
+.. _pyansys-openapi-client:
+
 pyansys-openapi-client
 ----------------------
 Create an OpenAPI Client Package project compliant with PyAnsys guidelines.
@@ -181,6 +191,7 @@ To create a new project using this template, run:
 
     Demo unavailable at the moment.
 
+.. _pyace:
 
 pyace
 -----
@@ -209,6 +220,8 @@ To create a new project using this template, run:
     `ansys-templates/demo - pyace-pkg <https://github.com/ansys/ansys-templates/tree/demo/pyace-pkg>`_
 
 
+.. _pyace-fast:
+
 pyace-fast
 ----------
 This template renders to a basic Python project compliant with the latest
@@ -235,6 +248,8 @@ To create a new project using this template, run:
 
     `ansys-templates/demo - pyace-fast <https://github.com/ansys/ansys-templates/tree/demo/pyace-fast>`_
 
+
+.. _pyace-flask:
 
 pyace-flask
 -----------
@@ -264,6 +279,8 @@ To create a new project using this template, run:
     `ansys-templates/demo - pyace-flask <https://github.com/ansys/ansys-templates/tree/demo/pyace-flask>`_
 
 
+.. _pyace-grpc:
+
 pyace-grpc
 ----------
 This template renders to a basic Python project compliant with the latest
@@ -289,6 +306,8 @@ To create a new project using this template, run:
 .. admonition:: Link to demo
 
     `ansys-templates/demo - pyace-grpc <https://github.com/ansys/ansys-templates/tree/demo/pyace-grpc>`_
+
+.. _solution:
 
 solution
 --------

--- a/doc/source/templates.rst
+++ b/doc/source/templates.rst
@@ -59,8 +59,6 @@ capabilities and features of each template:
    better idea on the final project layout.
 
 
-.. _doc-project:
-
 doc-project
 -----------
 This template renders a documentation project based on Sphinx. You can chose
@@ -83,7 +81,6 @@ To create a new project using this template by running:
 
     `ansys-templates/demo - doc-project <https://github.com/ansys/ansys-templates/tree/demo/doc-project>`_
 
-.. _pybasic:
 
 pybasic
 -------
@@ -110,7 +107,6 @@ To create a new project using this template by running:
     `ansys-templates/demo - pybasic <https://github.com/ansys/ansys-templates/tree/demo/pybasic>`_
 
 
-.. _pyansys:
 
 pyansys
 -------
@@ -136,8 +132,6 @@ To create a new project using this template, run:
 
     `ansys-templates/demo - pyansys <https://github.com/ansys/ansys-templates/tree/demo/pyansys>`_
 
-
-.. _pyansys-advanced:
 
 pyansys-advanced
 ----------------
@@ -169,8 +163,6 @@ To create a new project using this template, run:
     * `ansys-templates/demo - pyansys-advanced-setuptools <https://github.com/ansys/ansys-templates/tree/demo/pyansys-advanced-setuptools>`_
 
 
-.. _pyansys-openapi-client:
-
 pyansys-openapi-client
 ----------------------
 Create an OpenAPI Client Package project compliant with PyAnsys guidelines.
@@ -191,7 +183,6 @@ To create a new project using this template, run:
 
     Demo unavailable at the moment.
 
-.. _pyace:
 
 pyace
 -----
@@ -220,7 +211,6 @@ To create a new project using this template, run:
     `ansys-templates/demo - pyace-pkg <https://github.com/ansys/ansys-templates/tree/demo/pyace-pkg>`_
 
 
-.. _pyace-fast:
 
 pyace-fast
 ----------
@@ -249,7 +239,6 @@ To create a new project using this template, run:
     `ansys-templates/demo - pyace-fast <https://github.com/ansys/ansys-templates/tree/demo/pyace-fast>`_
 
 
-.. _pyace-flask:
 
 pyace-flask
 -----------
@@ -279,7 +268,6 @@ To create a new project using this template, run:
     `ansys-templates/demo - pyace-flask <https://github.com/ansys/ansys-templates/tree/demo/pyace-flask>`_
 
 
-.. _pyace-grpc:
 
 pyace-grpc
 ----------
@@ -307,7 +295,6 @@ To create a new project using this template, run:
 
     `ansys-templates/demo - pyace-grpc <https://github.com/ansys/ansys-templates/tree/demo/pyace-grpc>`_
 
-.. _solution:
 
 solution
 --------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ tests = [
 doc = [
     "ansys-sphinx-theme==0.16.0",
     "numpydoc==1.6.0",
-    "sphinx==7.2.6",
+    "sphinx==7.3.7",
     "sphinx-copybutton==0.5.2",
 ]
 


### PR DESCRIPTION
The docs build  was failing because of the autosectionlabel was on and there will be duplicated label in case of changelog. So supressing the autosection label warning
https://github.com/ansys/ansys-templates/actions/runs/9362587943/job/25771639895#step:2:975
.