### PR TITLE
fix: updating poetry.lock before local wheels are used in solution template

### DIFF
--- a/doc/changelog.d/495.fixed.md
+++ b/doc/changelog.d/495.fixed.md
@@ -1,0 +1,1 @@
+fix: updating poetry.lock before local wheels are used in solution template

--- a/src/ansys/templates/python/solution/{{cookiecutter.__project_name_slug}}/setup_environment.py
+++ b/src/ansys/templates/python/solution/{{cookiecutter.__project_name_slug}}/setup_environment.py
@@ -870,14 +870,14 @@ def update_lock_file_to_consider_local_wheels(args: object) -> None:
 
     print("Adapting lock file to consider local wheels.")
     subprocess.run(
-            [
-                DEPENDENCY_MANAGER_PATHS[sys.platform]["build_sys_exec"],
-                "lock",
-                "--no-update",
-            ],
-            check=True,
-            shell=DEPENDENCY_MANAGER_PATHS[sys.platform]["shell"],
-        )
+        [
+            DEPENDENCY_MANAGER_PATHS[sys.platform]["build_sys_exec"],
+            "lock",
+            "--no-update",
+        ],
+        check=True,
+        shell=DEPENDENCY_MANAGER_PATHS[sys.platform]["shell"],
+    )
 
 
 def install_production_dependencies(args: object) -> None:

--- a/src/ansys/templates/python/solution/{{cookiecutter.__project_name_slug}}/setup_environment.py
+++ b/src/ansys/templates/python/solution/{{cookiecutter.__project_name_slug}}/setup_environment.py
@@ -863,6 +863,23 @@ def clear_workspace(args: object) -> None:
     print()
 
 
+def update_lock_file_to_consider_local_wheels(args: object) -> None:
+    """Specify in the poetry.lock file that some packages come from a local wheel file."""
+    if not args.local_wheels:
+        return
+
+    print("Adapting lock file to consider local wheels.")
+    subprocess.run(
+            [
+                DEPENDENCY_MANAGER_PATHS[sys.platform]["build_sys_exec"],
+                "lock",
+                "--no-update",
+            ],
+            check=True,
+            shell=DEPENDENCY_MANAGER_PATHS[sys.platform]["shell"],
+        )
+
+
 def install_production_dependencies(args: object) -> None:
     """Install the package (mandatory requirements only)."""
     print("Install production dependencies")
@@ -1026,6 +1043,8 @@ def main() -> None:
     # Install dependencies --------------------------------------------------------------------------------------------
 
     print_section_header("Install dependencies", max_length=100)
+
+    update_lock_file_to_consider_local_wheels(args)
 
     install_production_dependencies(args)
 


### PR DESCRIPTION
It is considered as a good practice that whenever you change the `pyproject.toml` file, you should run `poetry lock --no-update` afterwards to sync the `poetry.lock` files with those changes. This is what we do when some packages are provided as wheel files through the `setup_environment.py`. The `--no-update` flag tries to preserve existing versions of dependencies. 

In this PR I am executing `poetry lock --no-update` as part of `setup_environment.py` before installing dependencies.