### PR TITLE
Update main documentation to remove internal-only limitation for the solution template

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,7 +108,7 @@ Available templates in ``ansys-templates`` are:
 - ``pyace-flask``: Create a Flask project initialized for any developer.
 - ``pyace-grpc``: Create gRPC project initialized for any developer.
 - ``pyace-fast``: Create a FastAPI project initialized for any developer.
-- ``solution``: Create a Solution based on the Solution Application Framework. **For Ansys Internal Use Only**
+- ``solution``: Create a Solution based on the Solution Application Framework.
 
 
 Template features
@@ -137,11 +137,9 @@ available in ``ansys-templates``:
 +-------------------------+-----------------------+-----------------+---------+----------+----------------+---------+
 | pyace-grpc              |  ``X``                |  ``X``          |  ``X``  |  ``X``   |  ``X``         |  ``X``  |
 +-------------------------+-----------------------+-----------------+---------+----------+----------------+---------+
-| solution "*"            |                       |  ``X``          |  ``X``  |  ``X``   |  ``X``         |         |
+| solution                |                       |  ``X``          |  ``X``  |  ``X``   |  ``X``         |         |
 +-------------------------+-----------------------+-----------------+---------+----------+----------------+---------+
 
-.. warning::
-    "*" This template is for **Ansys Internal Use Only**.
 
 Demo branches
 -------------

--- a/doc/changelog.d/505.documentation.md
+++ b/doc/changelog.d/505.documentation.md
@@ -1,1 +1,1 @@
-Docs/anskfletcher/ansys templates/update doc for public solution template
+Update main documentation to remove internal-only limitation for the solution template

--- a/doc/changelog.d/505.documentation.md
+++ b/doc/changelog.d/505.documentation.md
@@ -1,0 +1,1 @@
+Docs/anskfletcher/ansys templates/update doc for public solution template

--- a/doc/source/templates.rst
+++ b/doc/source/templates.rst
@@ -284,8 +284,8 @@ To create a new project using this template, run:
 
 solution
 --------
-This template renders to a Python project compliant with the latest Solutions
-Application guidelines:
+This template renders to a Python project compliant with the latest Solution
+Applications guidelines:
 
 Main features of this package are:
 
@@ -297,6 +297,7 @@ Main features of this package are:
 - Includes a ``tox.ini`` file.
 
 To create a new project using this template, run:
+
 .. code-block:: text
 
     ansys-templates new solution

--- a/doc/source/templates.rst
+++ b/doc/source/templates.rst
@@ -221,6 +221,7 @@ Main features of this package are:
 - Ability to integrate Docker within the project.
 
 To create a new project using this template, run:
+
 .. code-block:: text
 
     ansys-templates new pyace-fast
@@ -274,6 +275,7 @@ Main features of this package are:
 - Ability to integrate Docker within the project.
 
 To create a new project using this template, run:
+
 .. code-block:: text
 
     ansys-templates new pyace-grpc


### PR DESCRIPTION
- Update the README and "Templates" page on the main branch to remove the internal-only limitation on the `solution` template.
- On the "Templates" page, corrected code-block formatting for two other templates.